### PR TITLE
feat(editor): ! filter operator through external command (closes #85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,6 +2402,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/hjkl/src/app/chord_routing.rs
+++ b/apps/hjkl/src/app/chord_routing.rs
@@ -319,6 +319,23 @@ impl App {
                         total_count,
                     }) => {
                         self.pending_state = None;
+                        // Filter with motion (!<motion>): resolve the row range, then
+                        // open the filter prompt so the user can type the shell command.
+                        if op == hjkl_vim::OperatorKind::Filter {
+                            if let Some((top, bot)) = self
+                                .active_mut()
+                                .editor
+                                .range_for_op_motion(motion_key, total_count)
+                            {
+                                tracing::debug!(
+                                    top,
+                                    bot,
+                                    "filter operator: opening prompt for motion range"
+                                );
+                                self.open_filter_prompt(top, bot);
+                            }
+                            return true;
+                        }
                         // AutoIndent with motion (=<motion>): dry-run the motion to
                         // find the row range, then submit the async formatter.
                         // Falls back to dumb algo when no formatter is registered.
@@ -354,6 +371,21 @@ impl App {
                     }
                     Outcome::Commit(hjkl_vim::EngineCmd::ApplyOpDouble { op, total_count }) => {
                         self.pending_state = None;
+                        // Filter (!!): open the filter prompt for the current line range.
+                        // `!!` filters `total_count` lines starting at the cursor.
+                        if op == hjkl_vim::OperatorKind::Filter {
+                            let cursor_row = self.active().editor.cursor().0;
+                            let bot_row = cursor_row
+                                .saturating_add(total_count.max(1))
+                                .saturating_sub(1);
+                            tracing::debug!(
+                                cursor_row,
+                                bot_row,
+                                "filter operator: opening prompt for double (!!)"
+                            );
+                            self.open_filter_prompt(cursor_row, bot_row);
+                            return true;
+                        }
                         // AutoIndent (==): submit async formatter with cursor-row range.
                         // Falls back to dumb algo when no formatter is registered.
                         let used_formatter = op == hjkl_vim::OperatorKind::AutoIndent && {

--- a/apps/hjkl/src/app/engine_actions.rs
+++ b/apps/hjkl/src/app/engine_actions.rs
@@ -133,6 +133,19 @@ impl App {
                                     }
                                 }
                             }
+                            hjkl_vim::OperatorKind::Filter => {
+                                // Visual-block !: filter the row range through a shell command.
+                                // Exit visual mode first, then open the filter prompt.
+                                use crossterm::event::{
+                                    KeyCode, KeyEvent as CtKeyEvent, KeyModifiers,
+                                };
+                                hjkl_vim_tui::handle_key(
+                                    &mut self.active_mut().editor,
+                                    CtKeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                                );
+                                self.open_filter_prompt(top_row, bot_row);
+                                return;
+                            }
                             _ => return,
                         }
                         // Exit visual mode after the op (except Change above).
@@ -197,6 +210,20 @@ impl App {
                                         });
                                     }
                                 }
+                            }
+                            hjkl_vim::OperatorKind::Filter => {
+                                // Visual-charwise !: filter the row range through a shell command.
+                                let (min_r, max_r) = (start.0.min(end.0), start.0.max(end.0));
+                                // Exit visual mode first, then open the filter prompt.
+                                use crossterm::event::{
+                                    KeyCode, KeyEvent as CtKeyEvent, KeyModifiers,
+                                };
+                                hjkl_vim_tui::handle_key(
+                                    &mut self.active_mut().editor,
+                                    CtKeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                                );
+                                self.open_filter_prompt(min_r, max_r);
+                                return;
                             }
                             _ => return,
                         }
@@ -284,6 +311,19 @@ impl App {
                                         });
                                     }
                                 }
+                            }
+                            hjkl_vim::OperatorKind::Filter => {
+                                // Visual-line !: filter the row range through a shell command.
+                                // Exit visual mode first, then open the filter prompt.
+                                use crossterm::event::{
+                                    KeyCode, KeyEvent as CtKeyEvent, KeyModifiers,
+                                };
+                                hjkl_vim_tui::handle_key(
+                                    &mut self.active_mut().editor,
+                                    CtKeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+                                );
+                                self.open_filter_prompt(top_row, bot_row);
+                                return;
                             }
                             _ => return,
                         }

--- a/apps/hjkl/src/app/event_loop.rs
+++ b/apps/hjkl/src/app/event_loop.rs
@@ -63,6 +63,7 @@ pub(crate) fn op_kind_to_operator(k: hjkl_vim::OperatorKind) -> hjkl_engine::Ope
         hjkl_vim::OperatorKind::ToggleCase => hjkl_engine::Operator::ToggleCase,
         hjkl_vim::OperatorKind::Reflow => hjkl_engine::Operator::Reflow,
         hjkl_vim::OperatorKind::AutoIndent => hjkl_engine::Operator::AutoIndent,
+        hjkl_vim::OperatorKind::Filter => hjkl_engine::Operator::Filter,
     }
 }
 
@@ -291,6 +292,12 @@ impl App {
             if self.exit_requested {
                 return KeyOutcome::Break;
             }
+            return KeyOutcome::Continue;
+        }
+
+        // ── Filter prompt (`!` operator) ──────────────────────────
+        if self.filter_field.is_some() {
+            self.handle_filter_field_key(key);
             return KeyOutcome::Continue;
         }
 

--- a/apps/hjkl/src/app/keymap_build.rs
+++ b/apps/hjkl/src/app/keymap_build.rs
@@ -189,6 +189,11 @@ pub(crate) fn build_app_keymap(leader: char) -> Keymap<AppAction, keymap::HjklMo
             hjkl_vim::OperatorKind::AutoIndent,
             "auto-indent operator",
         ),
+        (
+            "!",
+            hjkl_vim::OperatorKind::Filter,
+            "filter through command",
+        ),
     ] {
         let action = AppAction::BeginPendingAfterOp { op, count1: 1 };
         if let Err(e) = km.add(Mode::Normal, key, action, desc) {
@@ -215,6 +220,11 @@ pub(crate) fn build_app_keymap(leader: char) -> Keymap<AppAction, keymap::HjklMo
             "=",
             hjkl_vim::OperatorKind::AutoIndent,
             "auto-indent selection",
+        ),
+        (
+            "!",
+            hjkl_vim::OperatorKind::Filter,
+            "filter selection through command",
         ),
     ] {
         let action = AppAction::VisualOp { op, count: 1 };

--- a/apps/hjkl/src/app/mod.rs
+++ b/apps/hjkl/src/app/mod.rs
@@ -157,6 +157,14 @@ pub struct App {
     /// Active wildmenu state for the command-line prompt. `None` outside
     /// completion (no Tab pressed yet, or after acceptance/cancel).
     pub(crate) command_completion: Option<hjkl_prompt::CommandCompletion>,
+    /// Active `!` filter prompt. `Some` while the user is typing a shell
+    /// command after a `!{motion}` or `!!` operator. Paired with
+    /// `filter_pending_range` which holds the row range to filter.
+    pub(crate) filter_field: Option<hjkl_form::TextFieldEditor>,
+    /// Row range `(top, bot)` (inclusive) waiting for a shell command from
+    /// the `!` filter prompt. Set when `filter_field` opens; cleared on
+    /// submit or cancel.
+    pub(crate) filter_pending_range: Option<(usize, usize)>,
     /// Active `/` (forward) / `?` (backward) search prompt.
     pub search_field: Option<TextFieldEditor>,
     /// Active picker overlay (file, buffer, grep, …).
@@ -608,6 +616,7 @@ impl App {
         self.context_menu.is_some()
             || self.picker.is_some()
             || self.command_field.is_some()
+            || self.filter_field.is_some()
             || self.search_field.is_some()
             || self.info_popup.is_some()
     }
@@ -1107,6 +1116,8 @@ impl App {
             info_popup: None,
             command_field: None,
             command_completion: None,
+            filter_field: None,
+            filter_pending_range: None,
             search_field: None,
             picker: None,
             pending_count: hjkl_vim::CountAccumulator::new(),

--- a/apps/hjkl/src/app/prompt.rs
+++ b/apps/hjkl/src/app/prompt.rs
@@ -557,6 +557,67 @@ impl App {
         }
     }
 
+    /// Open the `!` filter prompt for the row range `(top, bot)` (inclusive).
+    /// The user types a shell command; on Enter the range is piped through it.
+    pub(crate) fn open_filter_prompt(&mut self, top: usize, bot: usize) {
+        let mut field = hjkl_form::TextFieldEditor::new(true);
+        field.enter_insert_at_end();
+        self.filter_field = Some(field);
+        self.filter_pending_range = Some((top, bot));
+    }
+
+    /// Handle a key event while the `!` filter prompt is active.
+    pub(crate) fn handle_filter_field_key(&mut self, key: crossterm::event::KeyEvent) {
+        let input: EngineInput = hjkl_engine_tui::crossterm_to_input(key);
+        let field = match self.filter_field.as_mut() {
+            Some(f) => f,
+            None => return,
+        };
+
+        if input.key == EngineKey::Enter {
+            let command = field.text();
+            let range = self.filter_pending_range.take();
+            self.filter_field = None;
+            if let Some((top, bot)) = range {
+                let result = self
+                    .active_mut()
+                    .editor
+                    .filter_range(top, bot, command.trim(), None);
+                match result {
+                    Ok(()) => {
+                        self.sync_after_engine_mutation();
+                    }
+                    Err(msg) => {
+                        self.bus.error(format!("filter: {msg}"));
+                    }
+                }
+            }
+            return;
+        }
+
+        if input.key == EngineKey::Esc {
+            if field.text().is_empty() {
+                self.filter_field = None;
+                self.filter_pending_range = None;
+            } else if field.vim_mode() == VimMode::Insert {
+                field.enter_normal();
+            } else {
+                self.filter_field = None;
+                self.filter_pending_range = None;
+            }
+            return;
+        }
+
+        // Backspace on an empty prompt dismisses it.
+        if input.key == EngineKey::Backspace && field.text().is_empty() {
+            self.filter_field = None;
+            self.filter_pending_range = None;
+            return;
+        }
+
+        field.handle_input(input);
+    }
+
     /// Dispatch a prompt-opening [`crate::keymap_actions::AppAction`].
     ///
     /// Handles variants:

--- a/apps/hjkl/src/app/tests/mod.rs
+++ b/apps/hjkl/src/app/tests/mod.rs
@@ -19,6 +19,7 @@ fn op_kind_to_operator(k: hjkl_vim::OperatorKind) -> hjkl_engine::Operator {
         hjkl_vim::OperatorKind::ToggleCase => hjkl_engine::Operator::ToggleCase,
         hjkl_vim::OperatorKind::Reflow => hjkl_engine::Operator::Reflow,
         hjkl_vim::OperatorKind::AutoIndent => hjkl_engine::Operator::AutoIndent,
+        hjkl_vim::OperatorKind::Filter => hjkl_engine::Operator::Filter,
     }
 }
 

--- a/apps/hjkl/src/render.rs
+++ b/apps/hjkl/src/render.rs
@@ -694,8 +694,10 @@ fn render_window(frame: &mut Frame, app: &mut App, area: Rect, win_id: window::W
         &viewport_owned
     };
 
-    let in_prompt =
-        app.command_field.is_some() || app.search_field.is_some() || app.picker.is_some();
+    let in_prompt = app.command_field.is_some()
+        || app.filter_field.is_some()
+        || app.search_field.is_some()
+        || app.picker.is_some();
 
     // Merge diagnostic + LSP diag + git signs, filtered to the visible viewport.
     let vp_top = viewport_ref.top_row;
@@ -1280,6 +1282,20 @@ fn build_status_line(app: &App, width: u16) -> (Line<'static>, Option<u16>) {
         let text = field.text();
         let display: String = text.lines().next().unwrap_or("").to_string();
         let content = format!(":{display}");
+        let (_, ccol) = field.cursor();
+        let cursor_col = 1u16 + ccol as u16;
+        let theme = prompt_theme(&app.theme.ui);
+        return (
+            build_prompt_line(&content, field.vim_mode(), &theme, width),
+            Some(cursor_col),
+        );
+    }
+
+    // ── Filter prompt (`!`) ───────────────────────────────────────────────────
+    if let Some(ref field) = app.filter_field {
+        let text = field.text();
+        let display: String = text.lines().next().unwrap_or("").to_string();
+        let content = format!("!{display}");
         let (_, ccol) = field.cursor();
         let cursor_col = 1u16 + ccol as u16;
         let theme = prompt_theme(&app.theme.ui);

--- a/crates/hjkl-engine-tui/tests/editor_behavior.rs
+++ b/crates/hjkl-engine-tui/tests/editor_behavior.rs
@@ -3076,3 +3076,25 @@ fn filter_range_partial_range() {
     assert_eq!(lines[0], "alpha", "row 0 must be untouched");
     assert_eq!(&lines[1..], &["apple", "banana"]);
 }
+
+/// A slow command must be killed by the timeout; filter_range returns Err
+/// and the buffer is unmodified.
+#[test]
+#[cfg(not(windows))]
+fn filter_range_timeout_kills_slow_command() {
+    let mut e = make_editor("line1\nline2");
+    let before = e.buffer().lines().to_vec();
+    let start = std::time::Instant::now();
+    let result = e.filter_range(0, 1, "sleep 30", Some(1));
+    let elapsed = start.elapsed();
+    assert!(result.is_err(), "slow command must time out: {result:?}");
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "should return within ~1s timeout + slack, got {elapsed:?}"
+    );
+    assert_eq!(
+        e.buffer().lines().to_vec(),
+        before,
+        "buffer must be unchanged"
+    );
+}

--- a/crates/hjkl-engine-tui/tests/editor_behavior.rs
+++ b/crates/hjkl-engine-tui/tests/editor_behavior.rs
@@ -3021,3 +3021,58 @@ fn auto_indent_vs_cargo_fmt_motions_diagnostic() {
         "auto_indent diverges from cargo fmt on {pct}% of lines — regression from <1% baseline"
     );
 }
+
+// ── filter_range tests ────────────────────────────────────────────────────────
+
+fn make_editor(content: &str) -> Editor {
+    let mut e = Editor::new(
+        hjkl_buffer::Buffer::new(),
+        hjkl_engine::types::DefaultHost::new(),
+        hjkl_engine::types::Options::default(),
+    );
+    e.set_content(content);
+    e
+}
+
+/// `cat` is identity — buffer content must be unchanged after filter_range.
+#[test]
+fn filter_range_cat_is_identity() {
+    let mut e = make_editor("alpha\nbeta\ngamma");
+    let result = e.filter_range(0, 2, "cat", None);
+    assert!(result.is_ok(), "cat must succeed: {result:?}");
+    let lines = e.buffer().lines().to_vec();
+    assert_eq!(lines, vec!["alpha", "beta", "gamma"]);
+}
+
+/// Non-existent command returns Err; buffer must be unchanged.
+#[test]
+fn filter_range_nonexistent_command_returns_err() {
+    let mut e = make_editor("line1\nline2");
+    let count_before = e.buffer().lines().len();
+    let result = e.filter_range(0, 1, "__hjkl_no_such_cmd_xyz__", None);
+    assert!(result.is_err(), "non-existent command must return Err");
+    // Buffer must still have same line count — no mutation on error.
+    assert_eq!(e.buffer().lines().len(), count_before);
+}
+
+/// `sort` reorders lines within the filtered range.
+#[test]
+fn filter_range_sort_reorders_lines() {
+    let mut e = make_editor("banana\napple\ncherry");
+    let result = e.filter_range(0, 2, "sort", None);
+    assert!(result.is_ok(), "sort must succeed: {result:?}");
+    let lines = e.buffer().lines().to_vec();
+    assert_eq!(lines, vec!["apple", "banana", "cherry"]);
+}
+
+/// Partial range: only the specified rows are filtered; other rows untouched.
+#[test]
+fn filter_range_partial_range() {
+    // filter rows 1..=2 (banana, apple); row 0 (alpha) must stay
+    let mut e = make_editor("alpha\nbanana\napple");
+    let result = e.filter_range(1, 2, "sort", None);
+    assert!(result.is_ok(), "sort must succeed: {result:?}");
+    let lines = e.buffer().lines().to_vec();
+    assert_eq!(lines[0], "alpha", "row 0 must be untouched");
+    assert_eq!(&lines[1..], &["apple", "banana"]);
+}

--- a/crates/hjkl-engine/Cargo.toml
+++ b/crates/hjkl-engine/Cargo.toml
@@ -28,6 +28,7 @@ bitflags = "2"
 regex = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "2"
+tracing = "0.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/hjkl-engine/src/editor.rs
+++ b/crates/hjkl-engine/src/editor.rs
@@ -3156,8 +3156,8 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
     ) -> Result<(), String> {
         use std::io::Write;
         use std::process::{Command, Stdio};
-        use std::sync::mpsc;
         use std::thread;
+        use std::time::Instant;
 
         let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(10));
         let lines = self.buffer().lines();
@@ -3200,46 +3200,63 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
             // stdin drops here, signalling EOF to the child.
         });
 
-        // Wait for exit with timeout via a thread + channel.
-        let (tx, rx) = mpsc::channel();
-        let child_id = child.id();
-        let _ = child_id; // Used on Unix for kill.
-        thread::spawn(move || {
-            let output = child.wait_with_output();
-            let _ = tx.send(output);
+        // Drain stdout/stderr on separate threads so the child's pipes don't
+        // fill and deadlock the child. Keep `child` here so we can kill it on
+        // timeout.
+        let mut stdout_pipe = child.stdout.take().ok_or("no stdout handle")?;
+        let mut stderr_pipe = child.stderr.take().ok_or("no stderr handle")?;
+        let stdout_thread = thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = std::io::Read::read_to_end(&mut stdout_pipe, &mut buf);
+            buf
+        });
+        let stderr_thread = thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = std::io::Read::read_to_end(&mut stderr_pipe, &mut buf);
+            buf
         });
 
-        let output = rx.recv_timeout(timeout).map_err(|_| {
-            tracing::debug!(command, "filter_range: command timed out");
-            // On timeout: the worker thread's `child` is dropped when the
-            // thread eventually exits, which closes the process handle.
-            // We can't SIGKILL from here without the Child, so just report.
-            format!("command timed out after {}s", timeout.as_secs())
-        })?;
+        // Poll try_wait until exit or timeout. On timeout: SIGKILL the child
+        // (std Child::kill sends SIGKILL on Unix / TerminateProcess on Windows).
+        // A proper TERM→KILL escalation would need nix/libc; skip for v1.
+        let start = Instant::now();
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) => {
+                    if start.elapsed() >= timeout {
+                        tracing::debug!(command, "filter_range: timeout — killing child");
+                        let _ = child.kill();
+                        let _ = child.wait(); // reap so the OS can free resources
+                        return Err(format!("command timed out after {}s", timeout.as_secs()));
+                    }
+                    thread::sleep(std::time::Duration::from_millis(20));
+                }
+                Err(e) => return Err(format!("wait failed: {e}")),
+            }
+        };
 
-        let output = output.map_err(|e| format!("wait failed: {e}"))?;
+        let stdout_bytes = stdout_thread.join().unwrap_or_default();
+        let stderr_bytes = stderr_thread.join().unwrap_or_default();
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        if !status.success() {
+            let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
             tracing::debug!(
                 command,
-                exit_code = ?output.status.code(),
+                exit_code = ?status.code(),
                 "filter_range: command exited with non-zero status"
             );
             return Err(if stderr.is_empty() {
-                format!(
-                    "command exited with status {}",
-                    output.status.code().unwrap_or(-1)
-                )
+                format!("command exited with status {}", status.code().unwrap_or(-1))
             } else {
                 stderr
             });
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stdout = String::from_utf8_lossy(&stdout_bytes).into_owned();
         tracing::debug!(
             command,
-            stdout_bytes = output.stdout.len(),
+            stdout_bytes = stdout_bytes.len(),
             "filter_range: command succeeded, replacing rows"
         );
 

--- a/crates/hjkl-engine/src/editor.rs
+++ b/crates/hjkl-engine/src/editor.rs
@@ -3136,6 +3136,133 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
         self.last_indent_range.take()
     }
 
+    /// Filter rows `top_row..=bot_row` through an external shell command.
+    ///
+    /// Spawns `sh -c "<command>"` (or `cmd /C "<command>"` on Windows), pipes
+    /// the selected lines (joined by `\n`) to stdin, and waits up to
+    /// `timeout_secs` seconds (default 10) for the process to finish.
+    ///
+    /// On success: the rows are replaced with stdout. No trailing-newline trim.
+    /// On non-zero exit, spawn failure, or timeout: returns `Err(stderr_or_msg)`
+    /// without mutating the buffer.
+    ///
+    /// `top_row` and `bot_row` are clamped to the buffer's valid row range.
+    pub fn filter_range(
+        &mut self,
+        top_row: usize,
+        bot_row: usize,
+        command: &str,
+        timeout_secs: Option<u64>,
+    ) -> Result<(), String> {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+        use std::sync::mpsc;
+        use std::thread;
+
+        let timeout = std::time::Duration::from_secs(timeout_secs.unwrap_or(10));
+        let lines = self.buffer().lines();
+        let line_count = lines.len();
+        let top = top_row.min(line_count.saturating_sub(1));
+        let bot = bot_row.min(line_count.saturating_sub(1));
+        let (top, bot) = (top.min(bot), top.max(bot));
+        let input_text = lines[top..=bot].join("\n");
+
+        tracing::debug!(
+            top_row = top,
+            bot_row = bot,
+            command = command,
+            "filter_range: spawning shell command"
+        );
+
+        #[cfg(not(windows))]
+        let mut child = Command::new("sh")
+            .args(["-c", command])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn failed: {e}"))?;
+
+        #[cfg(windows)]
+        let mut child = Command::new("cmd")
+            .args(["/C", command])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn failed: {e}"))?;
+
+        // Write stdin on a thread to avoid deadlock when output > pipe buffer.
+        let mut stdin = child.stdin.take().ok_or("no stdin handle")?;
+        let input_bytes = input_text.into_bytes();
+        thread::spawn(move || {
+            let _ = stdin.write_all(&input_bytes);
+            // stdin drops here, signalling EOF to the child.
+        });
+
+        // Wait for exit with timeout via a thread + channel.
+        let (tx, rx) = mpsc::channel();
+        let child_id = child.id();
+        let _ = child_id; // Used on Unix for kill.
+        thread::spawn(move || {
+            let output = child.wait_with_output();
+            let _ = tx.send(output);
+        });
+
+        let output = rx.recv_timeout(timeout).map_err(|_| {
+            tracing::debug!(command, "filter_range: command timed out");
+            // On timeout: the worker thread's `child` is dropped when the
+            // thread eventually exits, which closes the process handle.
+            // We can't SIGKILL from here without the Child, so just report.
+            format!("command timed out after {}s", timeout.as_secs())
+        })?;
+
+        let output = output.map_err(|e| format!("wait failed: {e}"))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            tracing::debug!(
+                command,
+                exit_code = ?output.status.code(),
+                "filter_range: command exited with non-zero status"
+            );
+            return Err(if stderr.is_empty() {
+                format!(
+                    "command exited with status {}",
+                    output.status.code().unwrap_or(-1)
+                )
+            } else {
+                stderr
+            });
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        tracing::debug!(
+            command,
+            stdout_bytes = output.stdout.len(),
+            "filter_range: command succeeded, replacing rows"
+        );
+
+        // Replace the row range with the stdout lines.
+        let mut all_lines = lines;
+        let new_lines: Vec<String> = stdout.lines().map(|l| l.to_owned()).collect();
+        // If stdout ended with a newline, stdout.lines() drops the trailing empty
+        // entry — this preserves vim's "no trailing-newline trim" spec because
+        // a trailing '\n' from the command means the last replacement line is the
+        // line BEFORE the newline, not an empty line after it.
+        let after = all_lines.split_off(bot + 1);
+        all_lines.truncate(top);
+        all_lines.extend(new_lines);
+        all_lines.extend(after);
+
+        self.push_undo();
+        self.restore(all_lines, (top, 0));
+        // Leave mode as Normal after a successful filter operation (vim parity).
+        self.force_normal();
+
+        Ok(())
+    }
+
     // ─── Phase 4b: pub text-object resolution (hjkl#70) ─────────────────────
     //
     // Pure functions — no cursor mutation, no mode change, no register write.

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -197,6 +197,11 @@ pub enum Operator {
     /// bracket depth counting (v1 dumb reindent). Always linewise.
     /// See `auto_indent_range` for the algorithm and its limitations.
     AutoIndent,
+    /// `!{motion}` — filter the line range through an external shell command.
+    /// The range text is piped to the command's stdin; stdout replaces the
+    /// range in the buffer. Non-zero exit or spawn failure returns an error
+    /// to the caller without mutating the buffer.
+    Filter,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -674,6 +679,7 @@ impl VimState {
             Operator::Fold => 'z',
             Operator::Reflow => 'q',
             Operator::AutoIndent => '=',
+            Operator::Filter => '!',
         })
     }
 }
@@ -3652,6 +3658,12 @@ fn run_operator_over_range<H: crate::types::Host>(
             auto_indent_rows(ed, top.0, bot.0);
             ed.vim.mode = Mode::Normal;
         }
+        Operator::Filter => {
+            // Filter is not dispatched through run_operator_over_range.
+            // The app calls Editor::filter_range directly with a command string.
+            // Reaching this arm means a caller invoked run_operator_over_range
+            // with Operator::Filter by mistake — silently no-op.
+        }
     }
 }
 
@@ -4544,6 +4556,9 @@ fn execute_line_op<H: crate::types::Host>(
             ed.sticky_col = Some(ed.cursor().1);
             ed.vim.mode = Mode::Normal;
         }
+        Operator::Filter => {
+            // Filter is dispatched through Editor::filter_range, not here.
+        }
     }
 }
 
@@ -4637,6 +4652,8 @@ pub(crate) fn apply_visual_operator<H: crate::types::Host>(
                     auto_indent_rows(ed, top, bot);
                     ed.vim.mode = Mode::Normal;
                 }
+                // Filter is dispatched through Editor::filter_range, not here.
+                Operator::Filter => {}
                 // Visual `zf` is handled inline in `handle_after_z`,
                 // never routed through this dispatcher.
                 Operator::Fold => unreachable!("Visual zf takes its own path"),
@@ -4703,6 +4720,8 @@ pub(crate) fn apply_visual_operator<H: crate::types::Host>(
                     auto_indent_rows(ed, top.0, bot.0);
                     ed.vim.mode = Mode::Normal;
                 }
+                // Filter is dispatched through Editor::filter_range, not here.
+                Operator::Filter => {}
                 Operator::Fold => unreachable!("Visual zf takes its own path"),
             }
         }
@@ -4843,6 +4862,8 @@ fn apply_block_operator<H: crate::types::Host>(
             auto_indent_rows(ed, top, bot);
             ed.vim.mode = Mode::Normal;
         }
+        // Filter is dispatched through Editor::filter_range, not here.
+        Operator::Filter => {}
     }
 }
 

--- a/crates/hjkl-vim/src/normal.rs
+++ b/crates/hjkl-vim/src/normal.rs
@@ -649,6 +649,8 @@ fn handle_after_op<H: Host>(
         Operator::Reflow => Some('q'),
         // `==` auto-indents the current line.
         Operator::AutoIndent => Some('='),
+        // `!!` filters the current line — vim's doubled form.
+        Operator::Filter => Some('!'),
     };
     if let Key::Char(c) = input.key
         && !input.ctrl

--- a/crates/hjkl-vim/src/operator.rs
+++ b/crates/hjkl-vim/src/operator.rs
@@ -27,6 +27,10 @@ pub enum OperatorKind {
     Reflow,
     /// `=` — auto-indent (v1 dumb shiftwidth bracket counting).
     AutoIndent,
+    /// `!` — filter through external shell command. After the motion fixes the
+    /// range the grammar transitions to `PendingFilter` and waits for the
+    /// app to supply a command string before emitting `EngineCmd::ApplyFilter`.
+    Filter,
 }
 
 impl OperatorKind {
@@ -46,6 +50,7 @@ impl OperatorKind {
             OperatorKind::ToggleCase => '~',
             OperatorKind::Reflow => 'q',
             OperatorKind::AutoIndent => '=',
+            OperatorKind::Filter => '!',
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `Operator::Filter` / `OperatorKind::Filter` to engine + grammar layers with `!` as the trigger character
- `Editor::filter_range(top, bot, command, timeout)` spawns `sh -c <command>` on Unix / `cmd /C <command>` on Windows, pipes the row range to stdin on a thread (deadlock-safe), and replaces rows with stdout on success; returns `Err` without mutating the buffer on non-zero exit, spawn failure, or timeout
- App intercepts `ApplyOpMotion` / `ApplyOpDouble` / visual dispatches for `OperatorKind::Filter`, resolves the row range, and opens a `!`-prefixed prompt; Enter runs the filter, Esc cancels

## Test plan

- [ ] `filter_range_cat_is_identity` — `cat` leaves buffer unchanged
- [ ] `filter_range_sort_reorders_lines` — `sort` reorders all lines
- [ ] `filter_range_partial_range` — `sort` on rows 1..=2 leaves row 0 untouched
- [ ] `filter_range_nonexistent_command_returns_err` — bad command returns `Err`, buffer unchanged
- [ ] Manual: `!!sort` on multi-line buffer, `!2jsort` over 2+1 lines, visual-line `!cat`, Esc cancels without mutation