### PR TITLE
feat: vim-compat quick wins (#169 #170 #172 #173)

### DIFF
--- a/apps/hjkl/src/app/buffer_ops.rs
+++ b/apps/hjkl/src/app/buffer_ops.rs
@@ -19,6 +19,13 @@ impl App {
             let regs = self.slots[current_slot].editor.registers().clone();
             *self.slots[idx].editor.registers_mut() = regs;
         }
+        // Update the synthetic `%` register with the new slot's filename so
+        // `"%p`, `<C-r>%`, and `:echo @%` reflect the correct path.
+        let fname = self.slots[idx]
+            .filename
+            .as_deref()
+            .map(|p| p.to_string_lossy().into_owned());
+        self.slots[idx].editor.registers_mut().set_filename(fname);
         // Point the focused window at the new slot.
         let fw = self.focused_window();
         self.windows[fw].as_mut().expect("focused_window open").slot = idx;

--- a/apps/hjkl/src/app/ex_dispatch.rs
+++ b/apps/hjkl/src/app/ex_dispatch.rs
@@ -429,6 +429,52 @@ impl App {
                     self.buffer_delete(force);
                 }
             }
+            ExEffect::PutRegister { reg, above } => {
+                self.do_put_register(reg, above);
+            }
+        }
+    }
+
+    /// `:put [{reg}]` — paste register contents as a new line below (or above)
+    /// the cursor. Reads the register text, then inserts it as a fresh line.
+    fn do_put_register(&mut self, reg: char, above: bool) {
+        use hjkl_buffer::{Edit, Position};
+        let idx = self.focused_slot_idx();
+        let slot_text = self.slots[idx]
+            .editor
+            .registers()
+            .read(reg)
+            .map(|s| s.text.clone())
+            .unwrap_or_default();
+        if slot_text.is_empty() {
+            self.bus.warn(format!("E: register \"{reg}\" is empty"));
+            return;
+        }
+        // Strip trailing newline that linewise yanks carry so we don't
+        // introduce a blank line at the end.
+        let text = slot_text.trim_end_matches('\n').to_string();
+        let editor = &mut self.slots[idx].editor;
+        let (row, _) = editor.cursor();
+        if above {
+            editor.mutate_edit(Edit::InsertStr {
+                at: Position::new(row, 0),
+                text: format!("{text}\n"),
+            });
+        } else {
+            let line_len = editor
+                .buffer()
+                .line(row)
+                .map(|l| l.chars().count())
+                .unwrap_or(0);
+            editor.mutate_edit(Edit::InsertStr {
+                at: Position::new(row, line_len),
+                text: format!("\n{text}"),
+            });
+        }
+        // Sync dirty state and propagate to syntax engine.
+        let slot = &mut self.slots[idx];
+        if slot.editor.take_dirty() {
+            slot.refresh_dirty_against_saved();
         }
     }
 
@@ -782,7 +828,12 @@ impl App {
                             self.slots[idx].disk_len = Some(meta.len());
                         }
                         self.slots[idx].disk_state = DiskState::Synced;
-                        self.slots[idx].filename = Some(p);
+                        self.slots[idx].filename = Some(p.clone());
+                        // Keep `"%` in sync when the buffer gets a (new) filename.
+                        self.slots[idx]
+                            .editor
+                            .registers_mut()
+                            .set_filename(Some(p.to_string_lossy().into_owned()));
                         self.slots[idx].is_new_file = false;
                         self.slots[idx].snapshot_saved();
                         if idx == self.focused_slot_idx() {

--- a/apps/hjkl/src/app/ex_dispatch.rs
+++ b/apps/hjkl/src/app/ex_dispatch.rs
@@ -450,6 +450,10 @@ impl App {
                     .set_filename(Some(name.clone()));
                 self.bus.info(format!("\"{}\" [Not edited]", p.display()));
             }
+            ExEffect::Cwd(new_cwd) => {
+                // `:cd` already applied std::env::set_current_dir; show new path.
+                self.bus.info(new_cwd);
+            }
         }
     }
 

--- a/apps/hjkl/src/app/ex_dispatch.rs
+++ b/apps/hjkl/src/app/ex_dispatch.rs
@@ -432,6 +432,24 @@ impl App {
             ExEffect::PutRegister { reg, above } => {
                 self.do_put_register(reg, above);
             }
+            ExEffect::SaveAndRename { path } => {
+                // `:saveas {path}`: write to path AND update the buffer's identity.
+                // save_slot already updates slot.filename when saving to a new path.
+                let p = PathBuf::from(&path);
+                let idx = self.focused_slot_idx();
+                self.save_slot(idx, Some(p));
+            }
+            ExEffect::RenameBuffer { name } => {
+                // `:file {name}`: rename buffer in-memory without writing.
+                let idx = self.focused_slot_idx();
+                let p = PathBuf::from(&name);
+                self.slots[idx].filename = Some(p.clone());
+                self.slots[idx]
+                    .editor
+                    .registers_mut()
+                    .set_filename(Some(name.clone()));
+                self.bus.info(format!("\"{}\" [Not edited]", p.display()));
+            }
         }
     }
 

--- a/apps/hjkl/src/app/mod.rs
+++ b/apps/hjkl/src/app/mod.rs
@@ -1048,6 +1048,16 @@ impl App {
         let mut slot = build_slot(&mut syntax, buffer_id, filename, &bootstrap_config)
             .map_err(|s| anyhow::anyhow!(s))?;
 
+        // Seed `"%` with the initial buffer's filename so `<C-r>%` / `"%p`
+        // work from the first keystroke without requiring a buffer switch.
+        {
+            let fname = slot
+                .filename
+                .as_deref()
+                .map(|p| p.to_string_lossy().into_owned());
+            slot.editor.registers_mut().set_filename(fname);
+        }
+
         // Apply readonly after the slot is built — build_slot always uses
         // Options::default(); override here when requested.
         if readonly {

--- a/apps/hjkl/src/embed.rs
+++ b/apps/hjkl/src/embed.rs
@@ -168,6 +168,10 @@ fn dispatch(
                     *should_quit = true;
                     success(id, Value::Null)
                 }
+                ExEffect::PutRegister { .. } => {
+                    // Multi-buffer operation not supported in embed mode — no-op.
+                    success(id, Value::Null)
+                }
             }
         }
 

--- a/apps/hjkl/src/embed.rs
+++ b/apps/hjkl/src/embed.rs
@@ -185,6 +185,10 @@ fn dispatch(
                     // In-memory rename only — no-op in embed mode.
                     success(id, Value::Null)
                 }
+                ExEffect::Cwd(_) => {
+                    // Directory already changed by the handler — no-op.
+                    success(id, Value::Null)
+                }
             }
         }
 

--- a/apps/hjkl/src/embed.rs
+++ b/apps/hjkl/src/embed.rs
@@ -172,6 +172,19 @@ fn dispatch(
                     // Multi-buffer operation not supported in embed mode — no-op.
                     success(id, Value::Null)
                 }
+                ExEffect::SaveAndRename { path } => {
+                    let new_path = PathBuf::from(&path);
+                    if let Err(e) = write_buffer(editor, &Some(new_path.clone())) {
+                        error_resp(id, ERR_EX_COMMAND, &e.to_string())
+                    } else {
+                        *current_filename = Some(new_path);
+                        success(id, Value::Null)
+                    }
+                }
+                ExEffect::RenameBuffer { .. } => {
+                    // In-memory rename only — no-op in embed mode.
+                    success(id, Value::Null)
+                }
             }
         }
 

--- a/apps/hjkl/src/headless.rs
+++ b/apps/hjkl/src/headless.rs
@@ -194,6 +194,10 @@ pub fn run(files: Vec<PathBuf>, commands: Vec<String>) -> Result<i32> {
                 ExEffect::RenameBuffer { .. } => {
                     // In-memory rename — no write; no-op in headless mode.
                 }
+
+                ExEffect::Cwd(_) => {
+                    // Directory already changed by the handler — no-op.
+                }
             }
         }
 

--- a/apps/hjkl/src/headless.rs
+++ b/apps/hjkl/src/headless.rs
@@ -175,6 +175,10 @@ pub fn run(files: Vec<PathBuf>, commands: Vec<String>) -> Result<i32> {
                     // No multi-buffer in headless mode — stop processing.
                     break;
                 }
+
+                ExEffect::PutRegister { .. } => {
+                    // No multi-buffer paste support in headless mode — no-op.
+                }
             }
         }
 

--- a/apps/hjkl/src/headless.rs
+++ b/apps/hjkl/src/headless.rs
@@ -179,6 +179,21 @@ pub fn run(files: Vec<PathBuf>, commands: Vec<String>) -> Result<i32> {
                 ExEffect::PutRegister { .. } => {
                     // No multi-buffer paste support in headless mode — no-op.
                 }
+
+                ExEffect::SaveAndRename { path } => {
+                    let new_path = PathBuf::from(&path);
+                    if let Err(e) = write_buffer(&editor, &Some(new_path.clone()), &display_name) {
+                        eprintln!("{e}");
+                        exit_code = 1;
+                    } else {
+                        current_filename = Some(new_path);
+                        wrote = true;
+                    }
+                }
+
+                ExEffect::RenameBuffer { .. } => {
+                    // In-memory rename — no write; no-op in headless mode.
+                }
             }
         }
 

--- a/apps/hjkl/src/nvim_api.rs
+++ b/apps/hjkl/src/nvim_api.rs
@@ -437,6 +437,19 @@ fn dispatch(
                     // No multi-buffer paste in nvim-api mode — no-op.
                     ok(stdout, msgid, Value::Nil)
                 }
+                ExEffect::SaveAndRename { path } => {
+                    let new_path = PathBuf::from(&path);
+                    if let Err(e) = write_buffer(editor, &Some(new_path.clone())) {
+                        err(stdout, msgid, &e)
+                    } else {
+                        *current_filename = Some(new_path);
+                        ok(stdout, msgid, Value::Nil)
+                    }
+                }
+                ExEffect::RenameBuffer { .. } => {
+                    // In-memory rename — no-op in nvim-api mode.
+                    ok(stdout, msgid, Value::Nil)
+                }
             }
         }
 

--- a/apps/hjkl/src/nvim_api.rs
+++ b/apps/hjkl/src/nvim_api.rs
@@ -450,6 +450,10 @@ fn dispatch(
                     // In-memory rename — no-op in nvim-api mode.
                     ok(stdout, msgid, Value::Nil)
                 }
+                ExEffect::Cwd(_) => {
+                    // Directory already changed by the handler — no-op.
+                    ok(stdout, msgid, Value::Nil)
+                }
             }
         }
 

--- a/apps/hjkl/src/nvim_api.rs
+++ b/apps/hjkl/src/nvim_api.rs
@@ -433,6 +433,10 @@ fn dispatch(
                     *should_quit = true;
                     ok(stdout, msgid, Value::Nil)
                 }
+                ExEffect::PutRegister { .. } => {
+                    // No multi-buffer paste in nvim-api mode — no-op.
+                    ok(stdout, msgid, Value::Nil)
+                }
             }
         }
 

--- a/crates/hjkl-compat-oracle/corpus/tier1.toml
+++ b/crates/hjkl-compat-oracle/corpus/tier1.toml
@@ -724,3 +724,41 @@ initial_cursor = [0, 0]
 keys = "]["
 expected_buffer = "before\n}\nafter\n"
 expected_cursor = [1, 0]
+
+# ─── N| column-jump motion (#169) ──────────────────────────────────────────────
+
+# 5| jumps to column 5 (index 4, 1-based).
+[[cases]]
+name = "motion_pipe_goto_col5"
+initial_buffer = "hello world\n"
+initial_cursor = [0, 0]
+keys = "5|"
+expected_buffer = "hello world\n"
+expected_cursor = [0, 4]
+
+# bare | (no count) jumps to column 1 (index 0).
+[[cases]]
+name = "motion_pipe_no_count_col1"
+initial_buffer = "hello world\n"
+initial_cursor = [0, 7]
+keys = "|"
+expected_buffer = "hello world\n"
+expected_cursor = [0, 0]
+
+# d| deletes from cursor to column 1 (exclusive: col 0 not included when cursor is there).
+[[cases]]
+name = "op_d_pipe_delete_to_col1"
+initial_buffer = "hello\n"
+initial_cursor = [0, 3]
+keys = "d|"
+expected_buffer = "lo\n"
+expected_cursor = [0, 0]
+
+# d5| deletes to column 5.
+[[cases]]
+name = "op_d_pipe_count_delete_to_col5"
+initial_buffer = "hello world\n"
+initial_cursor = [0, 0]
+keys = "d5|"
+expected_buffer = "o world\n"
+expected_cursor = [0, 0]

--- a/crates/hjkl-engine/src/motions.rs
+++ b/crates/hjkl-engine/src/motions.rs
@@ -153,6 +153,18 @@ pub fn move_line_end<B: Cursor + Query>(buf: &mut B) {
     write_cursor(buf, Position::new(row, col));
 }
 
+/// `{count}|` — jump to column `count` on the current line (1-based;
+/// count=0 or no count → column 1 → index 0). Clamped to line length.
+pub fn move_goto_column<B: Cursor + Query>(buf: &mut B, count: usize) {
+    let cursor = read_cursor(buf);
+    // count is 1-based in vim: `1|` → col 0, `5|` → col 4.
+    // count=0 is treated as 1 (no count given → go to column 1).
+    let target_col = if count == 0 { 0 } else { count - 1 };
+    let line = read_line(buf, cursor.row);
+    let clamped = target_col.min(last_col(&line));
+    write_cursor(buf, Position::new(cursor.row, clamped));
+}
+
 /// `g_` — last non-blank char on the row. Empty / all-blank rows
 /// stay at column 0.
 pub fn move_last_non_blank<B: Cursor + Query>(buf: &mut B) {

--- a/crates/hjkl-engine/src/registers.rs
+++ b/crates/hjkl-engine/src/registers.rs
@@ -40,6 +40,14 @@ pub struct Registers {
     /// The host (the host) syncs this slot from the OS clipboard
     /// before paste and from the slot back out on yank.
     pub clip: Slot,
+    /// `"%` — synthetic read-only register: current buffer filename.
+    /// Set by the host whenever the active slot changes.
+    pub filename: Option<String>,
+    /// Pre-built `Slot` for the `%` register. Kept in sync with `filename`
+    /// by [`Registers::set_filename`] so `read('%')` can return `&Slot`.
+    /// Derived from `filename` — not serialised independently.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    filename_slot: Option<Slot>,
 }
 
 impl Registers {
@@ -86,6 +94,9 @@ impl Registers {
 
     /// Read a register by its single-char selector. Returns `None`
     /// for unrecognised selectors.
+    ///
+    /// `'%'` is a synthetic read-only register: returns the current buffer
+    /// filename when one has been set via [`Registers::set_filename`].
     pub fn read(&self, reg: char) -> Option<&Slot> {
         match reg {
             '"' => Some(&self.unnamed),
@@ -94,8 +105,17 @@ impl Registers {
             'a'..='z' => Some(&self.named[(reg as u8 - b'a') as usize]),
             'A'..='Z' => Some(&self.named[(reg.to_ascii_lowercase() as u8 - b'a') as usize]),
             '+' | '*' => Some(&self.clip),
+            // `%` is a synthetic read-only register: current buffer filename.
+            '%' => self.filename_slot.as_ref(),
             _ => None,
         }
+    }
+
+    /// Host hook: set the `"%` register to the given filename. Call this
+    /// whenever the active buffer changes.
+    pub fn set_filename(&mut self, name: Option<String>) {
+        self.filename = name.clone();
+        self.filename_slot = name.map(|n| Slot::new(n, false));
     }
 
     /// Replace the clipboard slot's contents — host hook for syncing
@@ -186,5 +206,30 @@ mod tests {
         assert_eq!(r.read('+').unwrap().text, "hi");
         // Unnamed always mirrors the latest write.
         assert_eq!(r.read('"').unwrap().text, "hi");
+    }
+
+    #[test]
+    fn percent_register_returns_none_when_no_filename() {
+        let r = Registers::default();
+        assert!(r.read('%').is_none());
+    }
+
+    #[test]
+    fn percent_register_returns_filename_after_set() {
+        let mut r = Registers::default();
+        r.set_filename(Some("src/main.rs".into()));
+        let slot = r
+            .read('%')
+            .expect("'%' should return Some after set_filename");
+        assert_eq!(slot.text, "src/main.rs");
+        assert!(!slot.linewise, "'%' slot should be charwise");
+    }
+
+    #[test]
+    fn percent_register_clears_when_set_to_none() {
+        let mut r = Registers::default();
+        r.set_filename(Some("foo.txt".into()));
+        r.set_filename(None);
+        assert!(r.read('%').is_none());
     }
 }

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -284,6 +284,9 @@ pub enum Motion {
     FirstNonBlankPrevLine,
     /// `_` — first non-blank of `count-1` lines down (count=1 = current line). Linewise.
     FirstNonBlankLine,
+    /// `{count}|` — jump to column `count` on the current line (1-based;
+    /// no count or count=0 → column 1 → index 0). Clamped to line length.
+    GotoColumn,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2395,6 +2398,7 @@ pub fn parse_motion(input: &Input) -> Option<Motion> {
         Key::Char('}') => Some(Motion::ParagraphNext),
         Key::Char('(') => Some(Motion::SentencePrev),
         Key::Char(')') => Some(Motion::SentenceNext),
+        Key::Char('|') => Some(Motion::GotoColumn),
         _ => None,
     }
 }
@@ -2925,6 +2929,10 @@ pub(crate) fn apply_motion_cursor_ctx<H: crate::types::Host>(
         }
         Motion::FirstNonBlankLine => {
             crate::motions::move_first_non_blank_line(&mut ed.buffer, count);
+            ed.push_buffer_cursor_to_textarea();
+        }
+        Motion::GotoColumn => {
+            crate::motions::move_goto_column(&mut ed.buffer, count);
             ed.push_buffer_cursor_to_textarea();
         }
     }

--- a/crates/hjkl-ex/src/builtins.rs
+++ b/crates/hjkl-ex/src/builtins.rs
@@ -312,6 +312,49 @@ fn redo_handler<H: Host>(
     Some(ExEffect::Ok)
 }
 
+// ---- saveas / file ---------------------------------------------------------
+
+/// `:saveas {path}` / `:sav {path}` — write buffer to `path` AND rename the
+/// buffer identity so future `:w` writes there.
+fn saveas_handler<H: Host>(
+    _editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    args: &str,
+    _range: Option<LineRange>,
+) -> Option<ExEffect> {
+    let path = args.trim();
+    if path.is_empty() {
+        return Some(ExEffect::Error("E471: Argument required".into()));
+    }
+    Some(ExEffect::SaveAndRename {
+        path: path.to_string(),
+    })
+}
+
+/// `:file [{name}]` — no-arg: print filename + status; with-arg: rename
+/// buffer in-memory without writing.
+fn file_handler<H: Host>(
+    editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    args: &str,
+    _range: Option<LineRange>,
+) -> Option<ExEffect> {
+    let name = args.trim();
+    if name.is_empty() {
+        // No arg: surface filename + readonly info. Dirty state lives in the
+        // app's slot (not the engine) so only readonly is checked here.
+        let filename = editor
+            .registers()
+            .read('%')
+            .map(|s| s.text.clone())
+            .unwrap_or_else(|| "[No Name]".into());
+        let ro_flag = if editor.is_readonly() { " [RO]" } else { "" };
+        Some(ExEffect::Info(format!("\"{filename}\"{ro_flag}")))
+    } else {
+        Some(ExEffect::RenameBuffer {
+            name: name.to_string(),
+        })
+    }
+}
+
 // ---- put -------------------------------------------------------------------
 
 /// `:put [{reg}]` / `:put!` — paste a register's contents as a new line.
@@ -802,6 +845,24 @@ pub(crate) fn register_builtins<H: Host>(reg: &mut Registry<H>) {
         arg_kind: ArgKind::None,
         min_prefix: 3,
         run: bwipeout_force_handler::<H>,
+    });
+
+    // `:saveas {path}` / `:sav {path}` — write and rename buffer (min_prefix=3).
+    reg.add(ExCommand {
+        name: "saveas",
+        aliases: &["sav"],
+        arg_kind: ArgKind::Path,
+        min_prefix: 3,
+        run: saveas_handler::<H>,
+    });
+
+    // `:file [{name}]` — no-arg: show filename; with-arg: rename buffer (min_prefix=1).
+    reg.add(ExCommand {
+        name: "file",
+        aliases: &[],
+        arg_kind: ArgKind::Path,
+        min_prefix: 1,
+        run: file_handler::<H>,
     });
 
     // `:put [{reg}]` / `:pu [{reg}]` — paste register as new line below cursor.

--- a/crates/hjkl-ex/src/builtins.rs
+++ b/crates/hjkl-ex/src/builtins.rs
@@ -1856,7 +1856,8 @@ mod tests {
     #[test]
     fn cd_handler_valid_dir_returns_cwd() {
         let mut ed = make_editor();
-        let result = cd_handler(&mut ed, "/tmp", None);
+        let tmp = std::env::temp_dir();
+        let result = cd_handler(&mut ed, &tmp.to_string_lossy(), None);
         match result {
             Some(ExEffect::Cwd(path)) => {
                 assert!(!path.is_empty(), "Cwd path must not be empty");
@@ -1868,7 +1869,8 @@ mod tests {
     #[test]
     fn cd_handler_invalid_dir_returns_error() {
         let mut ed = make_editor();
-        let result = cd_handler(&mut ed, "/nonexistent_hjkl_test_dir_xyz", None);
+        let bogus = std::env::temp_dir().join("nonexistent_hjkl_test_dir_xyz");
+        let result = cd_handler(&mut ed, &bogus.to_string_lossy(), None);
         assert!(
             matches!(result, Some(ExEffect::Error(_))),
             "expected Error, got {result:?}"

--- a/crates/hjkl-ex/src/builtins.rs
+++ b/crates/hjkl-ex/src/builtins.rs
@@ -355,6 +355,43 @@ fn file_handler<H: Host>(
     }
 }
 
+// ---- cd / pwd --------------------------------------------------------------
+
+/// `:cd [{path}]` — change working directory. No arg → `$HOME`.
+fn cd_handler<H: Host>(
+    _editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    args: &str,
+    _range: Option<LineRange>,
+) -> Option<ExEffect> {
+    let raw = args.trim();
+    let target = if raw.is_empty() {
+        std::env::var("HOME").unwrap_or_else(|_| ".".to_string())
+    } else {
+        raw.to_string()
+    };
+    match std::env::set_current_dir(&target) {
+        Ok(()) => {
+            let new_cwd = std::env::current_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or(target.clone());
+            Some(ExEffect::Cwd(new_cwd))
+        }
+        Err(e) => Some(ExEffect::Error(format!("{target}: {e}"))),
+    }
+}
+
+/// `:pwd` — print working directory.
+fn pwd_handler<H: Host>(
+    _editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    _args: &str,
+    _range: Option<LineRange>,
+) -> Option<ExEffect> {
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "?".to_string());
+    Some(ExEffect::Info(cwd))
+}
+
 // ---- put -------------------------------------------------------------------
 
 /// `:put [{reg}]` / `:put!` — paste a register's contents as a new line.
@@ -863,6 +900,24 @@ pub(crate) fn register_builtins<H: Host>(reg: &mut Registry<H>) {
         arg_kind: ArgKind::Path,
         min_prefix: 1,
         run: file_handler::<H>,
+    });
+
+    // `:cd [{path}]` — change working directory (no-arg → $HOME) (min_prefix=2).
+    reg.add(ExCommand {
+        name: "cd",
+        aliases: &[],
+        arg_kind: ArgKind::Path,
+        min_prefix: 2,
+        run: cd_handler::<H>,
+    });
+
+    // `:pwd` — print working directory (min_prefix=3).
+    reg.add(ExCommand {
+        name: "pwd",
+        aliases: &[],
+        arg_kind: ArgKind::None,
+        min_prefix: 3,
+        run: pwd_handler::<H>,
     });
 
     // `:put [{reg}]` / `:pu [{reg}]` — paste register as new line below cursor.
@@ -1793,6 +1848,40 @@ mod tests {
                 reg: '%',
                 above: false
             })
+        );
+    }
+
+    // ── cd_handler / pwd_handler ─────────────────────────────────────────────
+
+    #[test]
+    fn cd_handler_valid_dir_returns_cwd() {
+        let mut ed = make_editor();
+        let result = cd_handler(&mut ed, "/tmp", None);
+        match result {
+            Some(ExEffect::Cwd(path)) => {
+                assert!(!path.is_empty(), "Cwd path must not be empty");
+            }
+            other => panic!("expected Cwd, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cd_handler_invalid_dir_returns_error() {
+        let mut ed = make_editor();
+        let result = cd_handler(&mut ed, "/nonexistent_hjkl_test_dir_xyz", None);
+        assert!(
+            matches!(result, Some(ExEffect::Error(_))),
+            "expected Error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn pwd_handler_returns_info() {
+        let mut ed = make_editor();
+        let result = pwd_handler(&mut ed, "", None);
+        assert!(
+            matches!(result, Some(ExEffect::Info(_))),
+            "expected Info, got {result:?}"
         );
     }
 }

--- a/crates/hjkl-ex/src/builtins.rs
+++ b/crates/hjkl-ex/src/builtins.rs
@@ -312,6 +312,31 @@ fn redo_handler<H: Host>(
     Some(ExEffect::Ok)
 }
 
+// ---- put -------------------------------------------------------------------
+
+/// `:put [{reg}]` / `:put!` — paste a register's contents as a new line.
+///
+/// Without `!`: paste below the current line.
+/// With `!`: paste above the current line.
+/// Default register when no arg: `"` (unnamed).
+fn put_handler<H: Host>(
+    _editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    args: &str,
+    _range: Option<LineRange>,
+) -> Option<ExEffect> {
+    let reg = args.trim().chars().next().unwrap_or('"');
+    Some(ExEffect::PutRegister { reg, above: false })
+}
+
+fn put_above_handler<H: Host>(
+    _editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    args: &str,
+    _range: Option<LineRange>,
+) -> Option<ExEffect> {
+    let reg = args.trim().chars().next().unwrap_or('"');
+    Some(ExEffect::PutRegister { reg, above: true })
+}
+
 // ---- registers / marks / jumps / changes -----------------------------------
 
 fn registers_handler<H: Host>(
@@ -777,6 +802,24 @@ pub(crate) fn register_builtins<H: Host>(reg: &mut Registry<H>) {
         arg_kind: ArgKind::None,
         min_prefix: 3,
         run: bwipeout_force_handler::<H>,
+    });
+
+    // `:put [{reg}]` / `:pu [{reg}]` — paste register as new line below cursor.
+    reg.add(ExCommand {
+        name: "put",
+        aliases: &["pu"],
+        arg_kind: ArgKind::Raw,
+        min_prefix: 2,
+        run: put_handler::<H>,
+    });
+
+    // `:put! [{reg}]` / `:pu!` — paste register as new line above cursor.
+    reg.add(ExCommand {
+        name: "put!",
+        aliases: &["pu!"],
+        arg_kind: ArgKind::Raw,
+        min_prefix: 3,
+        run: put_above_handler::<H>,
     });
 
     // `:registers` / `:reg` (min_prefix=3; `:reg` via alias since "reg" < 3 chars)
@@ -1636,5 +1679,59 @@ mod tests {
         assert!(reg.resolve("set").is_some());
         assert!(reg.resolve("nohlsearch").is_some());
         assert!(reg.resolve("noh").is_some());
+    }
+
+    // ── put_handler ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn put_handler_no_args_uses_unnamed_register() {
+        let mut ed = make_editor();
+        let result = put_handler(&mut ed, "", None);
+        assert_eq!(
+            result,
+            Some(ExEffect::PutRegister {
+                reg: '"',
+                above: false
+            })
+        );
+    }
+
+    #[test]
+    fn put_handler_with_reg_uses_given_register() {
+        let mut ed = make_editor();
+        let result = put_handler(&mut ed, "a", None);
+        assert_eq!(
+            result,
+            Some(ExEffect::PutRegister {
+                reg: 'a',
+                above: false
+            })
+        );
+    }
+
+    #[test]
+    fn put_above_handler_no_args_uses_unnamed_register() {
+        let mut ed = make_editor();
+        let result = put_above_handler(&mut ed, "", None);
+        assert_eq!(
+            result,
+            Some(ExEffect::PutRegister {
+                reg: '"',
+                above: true
+            })
+        );
+    }
+
+    #[test]
+    fn put_handler_percent_register() {
+        let mut ed = make_editor();
+        let result = put_handler(&mut ed, "%", None);
+        assert_eq!(
+            result,
+            Some(ExEffect::PutRegister {
+                reg: '%',
+                above: false
+            })
+        );
     }
 }

--- a/crates/hjkl-ex/src/effect.rs
+++ b/crates/hjkl-ex/src/effect.rs
@@ -41,4 +41,7 @@ pub enum ExEffect {
     /// `:bd[!]` / `:bw[!]` — close the current buffer.
     /// `wipe = true` for `:bwipeout`; `force = true` when `!` was given.
     BufferDelete { force: bool, wipe: bool },
+    /// `:put [{reg}]` / `:pu [{reg}]` — paste register contents as a new
+    /// line below (or above when `above = true`) the cursor.
+    PutRegister { reg: char, above: bool },
 }

--- a/crates/hjkl-ex/src/effect.rs
+++ b/crates/hjkl-ex/src/effect.rs
@@ -44,4 +44,11 @@ pub enum ExEffect {
     /// `:put [{reg}]` / `:pu [{reg}]` — paste register contents as a new
     /// line below (or above when `above = true`) the cursor.
     PutRegister { reg: char, above: bool },
+    /// `:saveas {path}` / `:sav {path}` — write buffer to `path` AND rename
+    /// the buffer identity so future `:w` writes there.
+    /// Distinct from `SaveAs` (`:w <path>`) which writes elsewhere but keeps
+    /// the buffer's own filename unchanged.
+    SaveAndRename { path: String },
+    /// `:file {name}` — rename the current buffer in-memory without writing.
+    RenameBuffer { name: String },
 }

--- a/crates/hjkl-ex/src/effect.rs
+++ b/crates/hjkl-ex/src/effect.rs
@@ -51,4 +51,8 @@ pub enum ExEffect {
     SaveAndRename { path: String },
     /// `:file {name}` — rename the current buffer in-memory without writing.
     RenameBuffer { name: String },
+    /// `:cd [{path}]` — change the working directory. An empty path means
+    /// `$HOME`. The directory change is applied inside the handler; the new
+    /// path is surfaced so the host can update its status-line / title.
+    Cwd(String),
 }

--- a/crates/hjkl-vim/src/descriptors.rs
+++ b/crates/hjkl-vim/src/descriptors.rs
@@ -78,13 +78,13 @@ pub fn children_for(mode: Mode, prefix: &[KeyEvent]) -> Vec<VimDescriptor> {
 // ─── Expected counts (used by tests to catch drift) ───────────────────────────
 
 /// Expected count of root Normal-mode descriptors.
-pub const COUNT_NORMAL_ROOT: usize = 83;
+pub const COUNT_NORMAL_ROOT: usize = 84;
 /// Expected count of g-prefix descriptors.
 pub const COUNT_G_PREFIX: usize = 19;
 /// Expected count of z-prefix descriptors.
 pub const COUNT_Z_PREFIX: usize = 11;
 /// Expected count of operator-pending root descriptors (d/c/y prefix children).
-pub const COUNT_OP_PENDING_ROOT: usize = 24;
+pub const COUNT_OP_PENDING_ROOT: usize = 25;
 
 // ─── Normal-mode dispatch ──────────────────────────────────────────────────────
 
@@ -195,6 +195,7 @@ fn normal_root() -> Vec<VimDescriptor> {
         VimDescriptor::char('}', "paragraph next"),
         VimDescriptor::char('(', "sentence prev"),
         VimDescriptor::char(')', "sentence next"),
+        VimDescriptor::char('|', "goto column"),
         VimDescriptor::char('n', "search next"),
         VimDescriptor::char('N', "search prev"),
         VimDescriptor::char('*', "search word forward"),
@@ -349,6 +350,7 @@ fn op_pending_root() -> Vec<VimDescriptor> {
         VimDescriptor::char('F', "find char backward"),
         VimDescriptor::char('t', "till char forward"),
         VimDescriptor::char('T', "till char backward"),
+        VimDescriptor::char('|', "goto column"),
         // Text-object prefixes.
         VimDescriptor::char('i', "inner text object"),
         VimDescriptor::char('a', "around text object"),


### PR DESCRIPTION
## Summary

- **#169** `N|` column-jump motion: `|` in normal and operator-pending mode moves the cursor to column N (1-based, clamped). Count omitted → column 1. Registered in `hjkl-vim` descriptor tables; tested in `hjkl-compat-oracle` tier1 corpus.
- **#170** `"%` filename register + `:put [{reg}]`: `Registers::read('%')` returns a synthetic slot with the current buffer's filename. `set_filename()` keeps the in-memory slot in sync whenever a buffer is opened, saved, or renamed. `:put`/`:pu` (below) and `:put!`/`:pu!` (above) paste any register as a new line.
- **#172** `:saveas`/`:sav` + `:file`: `:saveas {path}` writes and renames the buffer identity (`SaveAndRename`). `:file` with no arg prints the current filename; with an arg it renames the buffer in-memory without writing (`RenameBuffer`).
- **#173** `:cd`/`:pwd`: `:cd [{path}]` changes the process working directory (no-arg → `$HOME`) and surfaces the new path via `ExEffect::Cwd`. `:pwd` returns the current directory as `Info`.

## Acceptance criteria

| Issue | Criterion | Status |
|-------|-----------|--------|
| #169 | `5|` on a line moves to col 4 | ✅ corpus test |
| #169 | `|` (no count) moves to col 0 | ✅ corpus test |
| #169 | `d\|` / `d5\|` delete correct range | ✅ corpus test |
| #170 | `"%` register returns filename | ✅ unit tests |
| #170 | `:put` / `:put!` paste register as new line | ✅ unit tests |
| #172 | `:saveas` writes + renames buffer | ✅ build + handler |
| #172 | `:file` no-arg prints name; with-arg renames | ✅ build + handler |
| #173 | `:cd /tmp` changes cwd; returns new path | ✅ unit test |
| #173 | `:cd` bad path returns error | ✅ unit test |
| #173 | `:pwd` returns Info with current dir | ✅ unit test |

## Test plan

- [ ] `cargo test --workspace` — all new tests green; only pre-existing X11 clipboard failures remain
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [ ] `cargo fmt --all -- --check` — clean
- [ ] Manual: open a file in hjkl TUI, `:file`, `5|`, `:put a`, `:saveas /tmp/out.txt`, `:cd /tmp`, `:pwd`