### PR TITLE
feat(ex): :& repeat-last-substitute (part of #171)

### DIFF
--- a/crates/hjkl-engine/src/editor.rs
+++ b/crates/hjkl-engine/src/editor.rs
@@ -441,6 +441,26 @@ use crate::buf_helpers::{
     buf_lines_to_vec, buf_row_count, buf_set_cursor_rc,
 };
 
+/// Return value from the engine's `try_goto_mark_*` methods. Tells the
+/// caller (app layer) whether a cross-buffer switch is required.
+///
+/// - `SameBuffer` — cursor moved (or mark was unset → no-op) within the
+///   same buffer; no buffer switch needed.
+/// - `CrossBuffer` — the mark lives in a different buffer. The app must
+///   switch to the slot whose `buffer_id` matches, then position the cursor
+///   at `(row, col)` using `Editor::jump_cursor`.
+/// - `Unset` — mark not set; no action needed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarkJump {
+    SameBuffer,
+    CrossBuffer {
+        buffer_id: u64,
+        row: usize,
+        col: usize,
+    },
+    Unset,
+}
+
 pub struct Editor<
     B: crate::types::Buffer = hjkl_buffer::Buffer,
     H: crate::types::Host = crate::types::DefaultHost,
@@ -786,26 +806,6 @@ fn settings_from_options(o: &crate::types::Options) -> Settings {
 pub enum LspIntent {
     /// `gd` — textDocument/definition at the cursor.
     GotoDefinition,
-}
-
-/// Result of `try_goto_mark_line` / `try_goto_mark_char`.
-///
-/// The host app inspects this to decide whether to switch buffers before
-/// completing the jump; the engine cannot switch buffers itself because
-/// it is single-buffer.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MarkJump {
-    /// Jump was executed within the current buffer.
-    SameBuffer,
-    /// Jump targets a different buffer. The host must switch to
-    /// `buffer_id` and then position the cursor at `(row, col)`.
-    CrossBuffer {
-        buffer_id: u64,
-        row: usize,
-        col: usize,
-    },
-    /// The mark was not set (silent no-op).
-    Unset,
 }
 
 impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
@@ -1827,6 +1827,17 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
     pub fn set_last_search(&mut self, text: Option<String>, forward: bool) {
         self.vim.last_search = text;
         self.vim.last_search_forward = forward;
+    }
+
+    /// The most recent successful `:s` command. `None` before the first substitute.
+    /// Used by `:&` / `:&&` to repeat it.
+    pub fn last_substitute(&self) -> Option<&crate::substitute::SubstituteCmd> {
+        self.vim.last_substitute.as_ref()
+    }
+
+    /// Store the last successful substitute so `:&` / `:&&` can repeat it.
+    pub fn set_last_substitute(&mut self, cmd: crate::substitute::SubstituteCmd) {
+        self.vim.last_substitute = Some(cmd);
     }
 
     /// Start/end `(row, col)` of the active char-wise Visual selection

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -510,6 +510,8 @@ pub struct VimState {
     /// sole source of truth; until then both fields are kept in sync.
     /// Initialized to `Normal` via `#[derive(Default)]`.
     pub(crate) current_mode: crate::VimMode,
+    /// Most recent successful :s invocation. Stored so :& / :&& can repeat it.
+    pub last_substitute: Option<crate::substitute::SubstituteCmd>,
 }
 
 pub(crate) const SEARCH_HISTORY_MAX: usize = 100;

--- a/crates/hjkl-ex/src/builtins.rs
+++ b/crates/hjkl-ex/src/builtins.rs
@@ -632,9 +632,8 @@ fn extract_leading_number(line: &str) -> i64 {
 /// expects.  No-range → current cursor line; with range the engine receives a
 /// 0-based inclusive `RangeInclusive<u32>`.
 ///
-/// `:&` and `:~` (repeat-last-substitute shortcuts) are NOT registered here.
-/// They use non-alphabetic names that `split_name_args` cannot parse; defer
-/// them to a future phase once the parse layer can handle bare-symbol commands.
+/// On success the parsed `SubstituteCmd` is stored on the editor so `:&` / `:&&`
+/// can repeat it (part of #171).
 fn substitute_handler<H: Host>(
     editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
     args: &str,
@@ -663,11 +662,69 @@ fn substitute_handler<H: Host>(
     };
 
     match apply_substitute(editor, &cmd, r) {
-        Ok(out) => Some(ExEffect::Substituted {
-            count: out.replacements,
-            lines_changed: out.lines_changed,
-        }),
+        Ok(out) => {
+            // Store so `:&` / `:&&` can repeat this substitution.
+            editor.set_last_substitute(cmd);
+            Some(ExEffect::Substituted {
+                count: out.replacements,
+                lines_changed: out.lines_changed,
+            })
+        }
         Err(e) => Some(ExEffect::Error(e.to_string())),
+    }
+}
+
+/// `:&` / `:&&` / `:[range]&` / `:[range]&&` — repeat last substitute.
+///
+/// `:&`  — repeat with original flags dropped (pattern and replacement kept).
+/// `:&&` — repeat with original flags preserved.
+///
+/// `keep_flags` is `true` for `&&`, `false` for `&`.
+pub(crate) fn repeat_substitute_handler<H: Host>(
+    editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    keep_flags: bool,
+    range: Option<LineRange>,
+) -> ExEffect {
+    use hjkl_engine::substitute::{SubstFlags, apply_substitute};
+
+    let cmd = match editor.last_substitute().cloned() {
+        Some(c) => c,
+        None => return ExEffect::Error("no previous substitute".into()),
+    };
+
+    // `:&` drops flags; `:&&` keeps them (vim semantics).
+    let effective_cmd = if keep_flags {
+        cmd
+    } else {
+        hjkl_engine::substitute::SubstituteCmd {
+            flags: SubstFlags::default(),
+            ..cmd
+        }
+    };
+
+    // Resolve range; default to current line.
+    let r = match range {
+        Some(lr) => {
+            let start = lr.start_one_based().saturating_sub(1) as u32;
+            let end = lr.end_one_based().saturating_sub(1) as u32;
+            start..=end
+        }
+        None => {
+            let row = editor.cursor().0 as u32;
+            row..=row
+        }
+    };
+
+    match apply_substitute(editor, &effective_cmd, r) {
+        Ok(out) => {
+            // Keep last_substitute updated with what was actually run.
+            editor.set_last_substitute(effective_cmd);
+            ExEffect::Substituted {
+                count: out.replacements,
+                lines_changed: out.lines_changed,
+            }
+        }
+        Err(e) => ExEffect::Error(e.to_string()),
     }
 }
 
@@ -1885,5 +1942,59 @@ mod tests {
             matches!(result, Some(ExEffect::Info(_))),
             "expected Info, got {result:?}"
         );
+    }
+
+    // ── repeat_substitute_handler (:& / :&&) ─────────────────────────────────
+
+    #[test]
+    fn repeat_substitute_no_prior_returns_error() {
+        let mut ed = make_editor_with_lines(&["foo"]);
+        let result = repeat_substitute_handler(&mut ed, false, None);
+        assert!(
+            matches!(result, ExEffect::Error(_)),
+            "expected Error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn repeat_substitute_repeats_on_current_line() {
+        let mut ed = make_editor_with_lines(&["foo", "foo"]);
+        substitute_handler(&mut ed, "/foo/bar", None);
+        assert_eq!(ed.buffer().line(0).unwrap_or_default(), "bar");
+        ed.goto_line(2);
+        let result = repeat_substitute_handler(&mut ed, false, None);
+        assert!(
+            matches!(result, ExEffect::Substituted { count: 1, .. }),
+            "expected Substituted(1), got {result:?}"
+        );
+        assert_eq!(ed.buffer().line(1).unwrap_or_default(), "bar");
+    }
+
+    #[test]
+    fn repeat_substitute_amp_amp_keeps_global_flag() {
+        let mut ed = make_editor_with_lines(&["x x x", "x x x"]);
+        substitute_handler(&mut ed, "/x/y/g", None);
+        assert_eq!(ed.buffer().line(0).unwrap_or_default(), "y y y");
+        ed.goto_line(2);
+        let result = repeat_substitute_handler(&mut ed, true, None);
+        assert!(
+            matches!(result, ExEffect::Substituted { count: 3, .. }),
+            "expected Substituted(3), got {result:?}"
+        );
+        assert_eq!(ed.buffer().line(1).unwrap_or_default(), "y y y");
+    }
+
+    #[test]
+    fn repeat_substitute_amp_drops_global_flag() {
+        let mut ed = make_editor_with_lines(&["x x x", "x x x"]);
+        substitute_handler(&mut ed, "/x/y/g", None);
+        assert_eq!(ed.buffer().line(0).unwrap_or_default(), "y y y");
+        ed.goto_line(2);
+        let result = repeat_substitute_handler(&mut ed, false, None);
+        assert!(
+            matches!(result, ExEffect::Substituted { count: 1, .. }),
+            "expected Substituted(1) (first only), got {result:?}"
+        );
+        assert_eq!(ed.buffer().line(1).unwrap_or_default(), "y x x");
     }
 }

--- a/crates/hjkl-ex/src/lib.rs
+++ b/crates/hjkl-ex/src/lib.rs
@@ -72,6 +72,17 @@ pub fn try_dispatch<H: hjkl_engine::Host>(
         return Some(shell::shell_filter_handler(editor, shell_cmd, range));
     }
 
+    // `:&` / `:&&` (repeat last substitute) — special-case because `&` is not
+    // alphabetic and split_name_args cannot parse it as a command name.
+    // `:&&` keeps the original flags; `:&` drops them (vim semantics).
+    // Must check `&&` before `&` so the double-ampersand form is matched first.
+    if cmd_str == "&&" || cmd_str.starts_with("&& ") {
+        return Some(builtins::repeat_substitute_handler(editor, true, range));
+    }
+    if cmd_str == "&" || cmd_str.starts_with("& ") {
+        return Some(builtins::repeat_substitute_handler(editor, false, range));
+    }
+
     let (name, args) = parse::split_name_args(cmd_str);
     if name.is_empty() {
         // Bare `:N` or bare range — jump to line.
@@ -1501,5 +1512,82 @@ mod tests {
             matches!(result, Some(ExEffect::Error(_))),
             "got: {result:?}"
         );
+    }
+
+    // ---- :& / :&& repeat-last-substitute ------------------------------------
+
+    #[test]
+    fn dispatch_amp_no_prior_sub_returns_error() {
+        let reg = default_registry::<DefaultHost>();
+        let mut editor = make_editor_with_lines(&["foo"]);
+        let result = try_dispatch(&reg, &mut editor, "&");
+        assert!(
+            matches!(result, Some(ExEffect::Error(_))),
+            "expected Error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn dispatch_amp_repeats_last_sub_on_current_line() {
+        let reg = default_registry::<DefaultHost>();
+        let mut editor = make_editor_with_lines(&["foo", "foo"]);
+        let r1 = try_dispatch(&reg, &mut editor, "s/foo/bar/");
+        assert!(
+            matches!(r1, Some(ExEffect::Substituted { count: 1, .. })),
+            "got: {r1:?}"
+        );
+        assert_eq!(editor.buffer().lines()[0], "bar");
+        editor.goto_line(2);
+        let r2 = try_dispatch(&reg, &mut editor, "&");
+        assert!(
+            matches!(r2, Some(ExEffect::Substituted { count: 1, .. })),
+            "expected Substituted(1), got {r2:?}"
+        );
+        assert_eq!(editor.buffer().lines()[1], "bar");
+    }
+
+    #[test]
+    fn dispatch_amp_amp_keeps_global_flag() {
+        let reg = default_registry::<DefaultHost>();
+        let mut editor = make_editor_with_lines(&["x x x", "x x x"]);
+        try_dispatch(&reg, &mut editor, "s/x/y/g").unwrap();
+        assert_eq!(editor.buffer().lines()[0], "y y y");
+        editor.goto_line(2);
+        let result = try_dispatch(&reg, &mut editor, "&&");
+        assert!(
+            matches!(result, Some(ExEffect::Substituted { count: 3, .. })),
+            "expected Substituted(3), got {result:?}"
+        );
+        assert_eq!(editor.buffer().lines()[1], "y y y");
+    }
+
+    #[test]
+    fn dispatch_amp_drops_global_flag() {
+        let reg = default_registry::<DefaultHost>();
+        let mut editor = make_editor_with_lines(&["x x x", "x x x"]);
+        try_dispatch(&reg, &mut editor, "s/x/y/g").unwrap();
+        assert_eq!(editor.buffer().lines()[0], "y y y");
+        editor.goto_line(2);
+        let result = try_dispatch(&reg, &mut editor, "&");
+        assert!(
+            matches!(result, Some(ExEffect::Substituted { count: 1, .. })),
+            "expected Substituted(1) (first only), got {result:?}"
+        );
+        assert_eq!(editor.buffer().lines()[1], "y x x");
+    }
+
+    #[test]
+    fn dispatch_percent_amp_repeats_on_whole_buffer() {
+        let reg = default_registry::<DefaultHost>();
+        let mut editor = make_editor_with_lines(&["foo", "foo", "bar"]);
+        try_dispatch(&reg, &mut editor, "s/foo/baz/").unwrap();
+        assert_eq!(editor.buffer().lines()[0], "baz");
+        let result = try_dispatch(&reg, &mut editor, "%&");
+        assert!(
+            matches!(result, Some(ExEffect::Substituted { count: 1, .. })),
+            "expected Substituted(1), got {result:?}"
+        );
+        assert_eq!(editor.buffer().lines()[1], "baz");
+        assert_eq!(editor.buffer().lines()[2], "bar");
     }
 }


### PR DESCRIPTION
## Summary

- Ships the `:&` half of #171; `:s///gc` interactive confirm remains open in #171.
- `:&` repeats the last `:s` on the current line, dropping the original flags (vim semantics).
- `:&&` repeats keeping the original flags (e.g. `g` stays global).
- `:[range]&` / `:[range]&&` forward the range correctly (e.g. `:%&` applies to the whole buffer).
- No new crate deps; no version bumps (workspace stays at 0.26.0).

## Implementation

- `VimState.last_substitute: Option<SubstituteCmd>` — persists the last parsed sub across the handler lifetime.
- `Editor::last_substitute` / `set_last_substitute` — public accessor/mutator.
- `substitute_handler` stores the cmd after every successful `apply_substitute`.
- `repeat_substitute_handler` (pub crate) handles `:&` / `:&&`; `keep_flags` controls flag retention.
- `try_dispatch` special-cases `&` / `&&` before `split_name_args`, mirroring the existing `!` shell-filter case.

## Test plan

- [ ] `dispatch_amp_no_prior_sub_returns_error` — no previous sub returns error
- [ ] `dispatch_amp_repeats_last_sub_on_current_line` — `:s/foo/bar/` then `:&` replaces on cursor line
- [ ] `dispatch_amp_amp_keeps_global_flag` — `:s/x/y/g` then `:&&` replaces all occurrences
- [ ] `dispatch_amp_drops_global_flag` — `:s/x/y/g` then `:&` replaces only first occurrence
- [ ] `dispatch_percent_amp_repeats_on_whole_buffer` — `:%&` applies to all lines
- [ ] Unit tests for `repeat_substitute_handler` directly in builtins
- [ ] All 458 hjkl-engine + hjkl-ex tests pass; clippy clean; fmt clean