### PR TITLE
feat(marks): uppercase global marks cross-buffer jump (closes #175)

### DIFF
--- a/apps/hjkl/src/app/buffer_ops.rs
+++ b/apps/hjkl/src/app/buffer_ops.rs
@@ -1,5 +1,5 @@
 use hjkl_buffer::Buffer;
-use hjkl_engine::{Editor, Host, Options};
+use hjkl_engine::{Editor, Host, MarkJump, Options};
 use hjkl_engine_tui::EditorRatatuiExt;
 use std::path::PathBuf;
 
@@ -26,6 +26,10 @@ impl App {
             .as_deref()
             .map(|p| p.to_string_lossy().into_owned());
         self.slots[idx].editor.registers_mut().set_filename(fname);
+        // Keep the engine's current_buffer_id in sync so `mA`–`mZ` global
+        // marks tag new marks with the correct slot id.
+        let new_bid = self.slots[idx].buffer_id;
+        self.slots[idx].editor.set_current_buffer_id(new_bid);
         // Point the focused window at the new slot.
         let fw = self.focused_window();
         self.windows[fw].as_mut().expect("focused_window open").slot = idx;
@@ -148,6 +152,7 @@ impl App {
             self.next_buffer_id += 1;
             let host = TuiHost::new();
             let mut editor = Editor::new(Buffer::new(), host, Options::default());
+            editor.set_current_buffer_id(new_id);
             if let Ok(size) = crossterm::terminal::size() {
                 let vp = editor.host_mut().viewport_mut();
                 vp.width = size.0;
@@ -250,6 +255,7 @@ impl App {
             self.next_buffer_id += 1;
             let host = TuiHost::new();
             let mut editor = Editor::new(Buffer::new(), host, Options::default());
+            editor.set_current_buffer_id(new_id);
             if let Ok(size) = crossterm::terminal::size() {
                 let vp = editor.host_mut().viewport_mut();
                 vp.width = size.0;
@@ -398,6 +404,45 @@ impl App {
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Handle the result of `Editor::try_goto_mark_line` /
+    /// `Editor::try_goto_mark_char`. Switches to the correct slot for cross-
+    /// buffer marks, positions the cursor, and syncs. Emits an error toast
+    /// when the referenced buffer has been closed.
+    pub(crate) fn apply_mark_jump(&mut self, jump: MarkJump, linewise: bool) {
+        match jump {
+            MarkJump::SameBuffer => {
+                self.sync_after_engine_mutation();
+            }
+            MarkJump::CrossBuffer {
+                buffer_id,
+                row,
+                col,
+            } => {
+                let slot_idx = self.slots.iter().position(|s| s.buffer_id == buffer_id);
+                match slot_idx {
+                    Some(idx) => {
+                        self.switch_to(idx);
+                        if linewise {
+                            self.active_mut().editor.jump_cursor(row, 0);
+                            self.active_mut()
+                                .editor
+                                .apply_motion(hjkl_vim::MotionKind::FirstNonBlank, 1);
+                        } else {
+                            self.active_mut().editor.jump_cursor(row, col);
+                        }
+                        self.sync_after_engine_mutation();
+                    }
+                    None => {
+                        self.bus.error(format!(
+                            "E474: mark references a closed buffer (id {buffer_id})"
+                        ));
+                    }
+                }
+            }
+            MarkJump::Unset => { /* silent no-op — mark not set */ }
         }
     }
 }

--- a/apps/hjkl/src/app/chord_routing.rs
+++ b/apps/hjkl/src/app/chord_routing.rs
@@ -534,14 +534,14 @@ impl App {
                     }
                     Outcome::Commit(hjkl_vim::EngineCmd::GotoMarkLine { ch }) => {
                         self.pending_state = None;
-                        self.active_mut().editor.goto_mark_line(ch);
-                        self.sync_after_engine_mutation();
+                        let jump = self.active_mut().editor.try_goto_mark_line(ch);
+                        self.apply_mark_jump(jump, true);
                         return true;
                     }
                     Outcome::Commit(hjkl_vim::EngineCmd::GotoMarkChar { ch }) => {
                         self.pending_state = None;
-                        self.active_mut().editor.goto_mark_char(ch);
-                        self.sync_after_engine_mutation();
+                        let jump = self.active_mut().editor.try_goto_mark_char(ch);
+                        self.apply_mark_jump(jump, false);
                         return true;
                     }
                     Outcome::Commit(hjkl_vim::EngineCmd::StartMacroRecord { reg }) => {

--- a/apps/hjkl/src/app/mod.rs
+++ b/apps/hjkl/src/app/mod.rs
@@ -438,6 +438,9 @@ pub(super) fn build_slot(
         hjkl_app::editorconfig::overlay_for_path(&mut ec_opts, p);
     }
     let mut editor = Editor::new(buffer, host, ec_opts);
+    // Tag the editor with its stable buffer_id so `mA`–`mZ` global marks
+    // record the correct id from the first keystroke.
+    editor.set_current_buffer_id(buffer_id);
     if let Ok(size) = crossterm::terminal::size() {
         let viewport_height = size.1.saturating_sub(STATUS_LINE_HEIGHT);
         let vp = editor.host_mut().viewport_mut();

--- a/apps/hjkl/src/app/tests/mod.rs
+++ b/apps/hjkl/src/app/tests/mod.rs
@@ -361,13 +361,13 @@ fn drive_key(app: &mut App, ct_key: KeyEvent) {
                 }
                 Outcome::Commit(hjkl_vim::EngineCmd::GotoMarkLine { ch }) => {
                     app.pending_state = None;
-                    app.active_mut().editor.goto_mark_line(ch);
+                    let _ = app.active_mut().editor.try_goto_mark_line(ch);
                     app.sync_viewport_from_editor();
                     return;
                 }
                 Outcome::Commit(hjkl_vim::EngineCmd::GotoMarkChar { ch }) => {
                     app.pending_state = None;
-                    app.active_mut().editor.goto_mark_char(ch);
+                    let _ = app.active_mut().editor.try_goto_mark_char(ch);
                     app.sync_viewport_from_editor();
                     return;
                 }

--- a/crates/hjkl-engine/src/editor.rs
+++ b/crates/hjkl-engine/src/editor.rs
@@ -524,6 +524,16 @@ pub struct Editor<
     /// and the `:marks` ex command. Mark-shift on edits is handled
     /// by [`Editor::shift_marks_after_edit`].
     pub(crate) marks: std::collections::BTreeMap<char, (usize, usize)>,
+    /// Global (uppercase) marks that carry a `buffer_id` so they can jump
+    /// across buffers. Keyed by `'A'`–`'Z'`; values are
+    /// `(buffer_id, row, col)`. Set by `m{A-Z}`, resolved by
+    /// `try_goto_mark_line` / `try_goto_mark_char`.
+    pub(crate) global_marks: std::collections::BTreeMap<char, (u64, usize, usize)>,
+    /// The `buffer_id` this editor instance is currently attached to.
+    /// Updated by the host app on every `switch_to` / slot creation so
+    /// global-mark writes record the correct id without requiring the app
+    /// to pass the id on every keystroke.
+    pub(crate) current_buffer_id: u64,
     /// Block ranges (`(start_row, end_row)` inclusive) the host has
     /// extracted from a syntax tree. `:foldsyntax` reads these to
     /// populate folds. The host refreshes them on every re-parse via
@@ -778,6 +788,26 @@ pub enum LspIntent {
     GotoDefinition,
 }
 
+/// Result of `try_goto_mark_line` / `try_goto_mark_char`.
+///
+/// The host app inspects this to decide whether to switch buffers before
+/// completing the jump; the engine cannot switch buffers itself because
+/// it is single-buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MarkJump {
+    /// Jump was executed within the current buffer.
+    SameBuffer,
+    /// Jump targets a different buffer. The host must switch to
+    /// `buffer_id` and then position the cursor at `(row, col)`.
+    CrossBuffer {
+        buffer_id: u64,
+        row: usize,
+        col: usize,
+    },
+    /// The mark was not set (silent no-op).
+    Unset,
+}
+
 impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
     /// Build an [`Editor`] from a buffer, host adapter, and SPEC options.
     ///
@@ -807,6 +837,8 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
             styled_spans: Vec::new(),
             settings,
             marks: std::collections::BTreeMap::new(),
+            global_marks: std::collections::BTreeMap::new(),
+            current_buffer_id: 0,
             syntax_fold_ranges: Vec::new(),
             change_log: Vec::new(),
             sticky_col: None,
@@ -918,6 +950,36 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
     /// Remove the named mark `c` (no-op if unset).
     pub fn clear_mark(&mut self, c: char) {
         self.marks.remove(&c);
+    }
+
+    /// Look up an uppercase global mark by letter. Returns
+    /// `(buffer_id, row, col)` if set; `None` otherwise.
+    pub fn global_mark(&self, c: char) -> Option<(u64, usize, usize)> {
+        self.global_marks.get(&c).copied()
+    }
+
+    /// Set an uppercase global mark `c` to `(buffer_id, row, col)`.
+    pub fn set_global_mark(&mut self, c: char, buffer_id: u64, pos: (usize, usize)) {
+        self.global_marks.insert(c, (buffer_id, pos.0, pos.1));
+    }
+
+    /// Return the `buffer_id` this editor is currently attached to.
+    pub fn current_buffer_id(&self) -> u64 {
+        self.current_buffer_id
+    }
+
+    /// Update the `buffer_id` this editor is attached to. Called by the
+    /// app on every `switch_to` so global-mark sets record the correct id.
+    pub fn set_current_buffer_id(&mut self, id: u64) {
+        self.current_buffer_id = id;
+    }
+
+    /// Iterate all global marks (`'A'`–`'Z'`), yielding
+    /// `(mark_char, buffer_id, row, col)`.
+    pub fn global_marks_iter(&self) -> impl Iterator<Item = (char, u64, usize, usize)> + '_ {
+        self.global_marks
+            .iter()
+            .map(|(c, &(bid, r, col))| (*c, bid, r, col))
     }
 
     /// Look up a buffer-local lowercase mark (`'a`–`'z`). Kept as a
@@ -1563,6 +1625,23 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
             self.marks.remove(&c);
         }
 
+        // Shift global marks that belong to the current buffer.
+        let cur_bid = self.current_buffer_id;
+        let mut global_to_drop: Vec<char> = Vec::new();
+        for (c, (bid, row, _col)) in self.global_marks.iter_mut() {
+            if *bid != cur_bid {
+                continue;
+            }
+            if (edit_start..drop_end).contains(row) {
+                global_to_drop.push(*c);
+            } else if *row >= shift_threshold {
+                *row = ((*row as isize) + delta).max(0) as usize;
+            }
+        }
+        for c in global_to_drop {
+            self.global_marks.remove(&c);
+        }
+
         let shift_jumps = |entries: &mut Vec<(usize, usize)>| {
             entries.retain(|(row, _)| !(edit_start..drop_end).contains(row));
             for (row, _) in entries.iter_mut() {
@@ -2182,6 +2261,11 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
             .iter()
             .map(|(c, (r, col))| (*c, (*r as u32, *col as u32)))
             .collect();
+        let global_marks = self
+            .global_marks
+            .iter()
+            .map(|(c, &(bid, r, col))| (*c, (bid, r as u32, col as u32)))
+            .collect();
         EditorSnapshot {
             version: EditorSnapshot::VERSION,
             mode,
@@ -2190,6 +2274,7 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
             viewport_top,
             registers: self.registers.clone(),
             marks,
+            global_marks,
         }
     }
 
@@ -2220,6 +2305,11 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
             .marks
             .into_iter()
             .map(|(c, (r, col))| (c, (r as usize, col as usize)))
+            .collect();
+        self.global_marks = snap
+            .global_marks
+            .into_iter()
+            .map(|(c, (bid, r, col))| (c, (bid, r as usize, col as usize)))
             .collect();
         Ok(())
     }
@@ -3629,6 +3719,24 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
     /// `EngineCmd::GotoMarkChar` without re-entering the engine FSM.
     pub fn goto_mark_char(&mut self, ch: char) {
         vim::goto_mark(self, ch, false);
+    }
+
+    /// Jump to the mark named `ch`, linewise. For uppercase marks (`'A'`–`'Z'`)
+    /// that live in a different buffer, returns `MarkJump::CrossBuffer` so the
+    /// app can switch slots before positioning the cursor. Returns
+    /// `MarkJump::SameBuffer` for same-buffer / lowercase / special marks, and
+    /// `MarkJump::Unset` when the mark is not set.
+    pub fn try_goto_mark_line(&mut self, ch: char) -> MarkJump {
+        vim::try_goto_mark(self, ch, true)
+    }
+
+    /// Jump to the mark named `ch`, charwise. For uppercase marks (`'A'`–`'Z'`)
+    /// that live in a different buffer, returns `MarkJump::CrossBuffer` so the
+    /// app can switch slots before positioning the cursor. Returns
+    /// `MarkJump::SameBuffer` for same-buffer / lowercase / special marks, and
+    /// `MarkJump::Unset` when the mark is not set.
+    pub fn try_goto_mark_char(&mut self, ch: char) -> MarkJump {
+        vim::try_goto_mark(self, ch, false)
     }
 
     // ── Macro controller API (Phase 5b) ──────────────────────────────────────

--- a/crates/hjkl-engine/src/lib.rs
+++ b/crates/hjkl-engine/src/lib.rs
@@ -33,7 +33,7 @@ pub mod types;
 mod viewport_math;
 mod vim;
 
-pub use editor::{Editor, LspIntent, StepBookkeeping};
+pub use editor::{Editor, LspIntent, MarkJump, StepBookkeeping};
 pub use input::{Input, Key, decode_macro, from_planned as decode_planned_input};
 pub use registers::{Registers, Slot};
 

--- a/crates/hjkl-engine/src/types.rs
+++ b/crates/hjkl-engine/src/types.rs
@@ -957,14 +957,17 @@ pub struct EditorSnapshot {
     /// Skipped for `Eq`/`PartialEq` because [`crate::Registers`]
     /// doesn't derive them today.
     pub registers: crate::Registers,
-    /// Named marks — both lowercase (`'a`–`'z`, buffer-scope) and
-    /// uppercase (`'A`–`'Z`, file-scope). Round-trips across tab
-    /// swaps in the host.
+    /// Named marks — lowercase (`'a`–`'z`, buffer-scope). Round-trips
+    /// across tab swaps in the host.
     ///
     /// 0.0.36: consolidated from the prior `file_marks` field;
     /// lowercase marks now persist as well since they live in the
     /// same unified [`crate::Editor::marks`] map.
     pub marks: std::collections::BTreeMap<char, (u32, u32)>,
+    /// Global (file) marks — uppercase (`'A`–`'Z`). Each entry records
+    /// `(buffer_id, row, col)` so cross-buffer jumps can switch to the
+    /// correct slot. Added in VERSION 5.
+    pub global_marks: std::collections::BTreeMap<char, (u64, u32, u32)>,
 }
 
 /// Status-line mode summary. Bridges to the legacy
@@ -988,6 +991,8 @@ impl EditorSnapshot {
     /// Bumped to 3 in v0.0.9: file_marks added.
     /// Bumped to 4 in v0.0.36: file_marks → unified `marks` map
     /// (lowercase + uppercase consolidated).
+    /// Bumped to 5: `global_marks` field added for cross-buffer uppercase
+    /// marks (closes #175).
     ///
     /// # Lock policy
     ///
@@ -1000,7 +1005,7 @@ impl EditorSnapshot {
     ///   the entire 0.1.x line.
     /// - **0.2.0+:** any further structural change requires `VERSION++`
     ///   together with a major-version bump of `hjkl-engine`.
-    pub const VERSION: u32 = 4;
+    pub const VERSION: u32 = 5;
 }
 
 /// Errors surfaced from the engine to the host. Intentionally narrow —
@@ -1428,7 +1433,7 @@ mod tests {
 
     #[test]
     fn editor_snapshot_version_const() {
-        assert_eq!(EditorSnapshot::VERSION, 4);
+        assert_eq!(EditorSnapshot::VERSION, 5);
     }
 
     #[test]
@@ -1441,6 +1446,7 @@ mod tests {
             viewport_top: 0,
             registers: crate::Registers::default(),
             marks: Default::default(),
+            global_marks: Default::default(),
         };
         assert_eq!(s.cursor, (0, 0));
         assert_eq!(s.lines.len(), 1);
@@ -1450,8 +1456,9 @@ mod tests {
     #[test]
     fn editor_snapshot_roundtrip() {
         let mut marks = std::collections::BTreeMap::new();
-        marks.insert('A', (5u32, 2u32));
         marks.insert('a', (1u32, 0u32));
+        let mut global_marks = std::collections::BTreeMap::new();
+        global_marks.insert('A', (42u64, 5u32, 2u32));
         let s = EditorSnapshot {
             version: EditorSnapshot::VERSION,
             mode: SnapshotMode::Insert,
@@ -1460,12 +1467,14 @@ mod tests {
             viewport_top: 2,
             registers: crate::Registers::default(),
             marks,
+            global_marks,
         };
         let json = serde_json::to_string(&s).unwrap();
         let back: EditorSnapshot = serde_json::from_str(&json).unwrap();
         assert_eq!(s.cursor, back.cursor);
         assert_eq!(s.lines, back.lines);
         assert_eq!(s.viewport_top, back.viewport_top);
+        assert_eq!(s.global_marks, back.global_marks);
     }
 
     #[test]

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -2186,32 +2186,39 @@ pub(crate) fn set_mark_at_cursor<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
     ch: char,
 ) {
-    if ch.is_ascii_lowercase() || ch.is_ascii_uppercase() {
-        // 0.0.36: lowercase + uppercase marks share the unified
-        // `Editor::marks` map. Uppercase entries survive
-        // `set_content` so they persist across tab swaps within the
-        // same Editor (the map lives on the Editor, not the buffer).
+    if ch.is_ascii_lowercase() {
         let pos = ed.cursor();
         ed.set_mark(ch, pos);
+    } else if ch.is_ascii_uppercase() {
+        let pos = ed.cursor();
+        let bid = ed.current_buffer_id();
+        ed.set_global_mark(ch, bid, pos);
+        tracing::debug!(
+            mark = ch as u32,
+            buffer_id = bid,
+            row = pos.0,
+            col = pos.1,
+            "global mark set"
+        );
     }
     // Invalid chars silently no-op (mirrors handle_set_mark behaviour).
 }
 
-/// `'<ch>` / `` `<ch> `` — public controller entry point. Validates `ch`
-/// against the set of legal mark names (lowercase, uppercase, special:
-/// `'`/`` ` ``/`.`/`[`/`]`/`<`/`>`), resolves the target position, and
-/// jumps the cursor. `linewise = true` → row only, col snaps to first
-/// non-blank; `linewise = false` → exact (row, col). Called by
-/// `Editor::goto_mark_line` / `Editor::goto_mark_char` so that hjkl-vim's
-/// `PendingState::GotoMarkLine` / `GotoMarkChar` reducers can dispatch
-/// without re-entering the engine FSM.
+/// `'<ch>` / `` `<ch> `` — public controller entry point for lowercase and
+/// special marks. Validates `ch` against the set of legal mark names
+/// (lowercase, special: `'`/`` ` ``/`.`/`[`/`]`/`<`/`>`), resolves the
+/// target position, and jumps the cursor. `linewise = true` → row only, col
+/// snaps to first non-blank; `linewise = false` → exact (row, col).
+///
+/// Uppercase marks are handled by [`try_goto_mark`] which can return a
+/// `MarkJump::CrossBuffer` for cross-buffer jumps.
 pub(crate) fn goto_mark<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
     ch: char,
     linewise: bool,
 ) {
     let target = match ch {
-        'a'..='z' | 'A'..='Z' => ed.mark(ch),
+        'a'..='z' => ed.mark(ch),
         '\'' | '`' => ed.vim.jump_back.last().copied(),
         '.' => ed.vim.last_edit_pos,
         '[' | ']' | '<' | '>' => ed.mark(ch),
@@ -2234,6 +2241,64 @@ pub(crate) fn goto_mark<H: crate::types::Host>(
         ed.push_jump(pre);
     }
     ed.sticky_col = Some(ed.cursor().1);
+}
+
+/// Unified mark-jump entry point that returns a [`crate::editor::MarkJump`]
+/// so the app layer can decide whether to switch buffers.
+///
+/// - Uppercase marks (`'A'`–`'Z'`) look in `global_marks`. If the stored
+///   `buffer_id` differs from `ed.current_buffer_id()`, returns
+///   `CrossBuffer`. Same-buffer uppercase marks execute the jump normally.
+/// - All other legal mark chars delegate to [`goto_mark`] and return
+///   `SameBuffer`.
+pub(crate) fn try_goto_mark<H: crate::types::Host>(
+    ed: &mut Editor<hjkl_buffer::Buffer, H>,
+    ch: char,
+    linewise: bool,
+) -> crate::editor::MarkJump {
+    use crate::editor::MarkJump;
+    match ch {
+        'A'..='Z' => {
+            let Some((bid, row, col)) = ed.global_mark(ch) else {
+                return MarkJump::Unset;
+            };
+            if bid != ed.current_buffer_id() {
+                tracing::debug!(
+                    mark = ch as u32,
+                    buffer_id = bid,
+                    row,
+                    col,
+                    "global mark cross-buffer jump"
+                );
+                return MarkJump::CrossBuffer {
+                    buffer_id: bid,
+                    row,
+                    col,
+                };
+            }
+            // Same buffer — execute the jump normally.
+            let pre = ed.cursor();
+            let (r, c_clamped) = clamp_pos(ed, (row, col));
+            if linewise {
+                buf_set_cursor_rc(&mut ed.buffer, r, 0);
+                ed.push_buffer_cursor_to_textarea();
+                move_first_non_whitespace(ed);
+            } else {
+                buf_set_cursor_rc(&mut ed.buffer, r, c_clamped);
+                ed.push_buffer_cursor_to_textarea();
+            }
+            if ed.cursor() != pre {
+                ed.push_jump(pre);
+            }
+            ed.sticky_col = Some(ed.cursor().1);
+            MarkJump::SameBuffer
+        }
+        'a'..='z' | '\'' | '`' | '.' | '[' | ']' | '<' | '>' => {
+            goto_mark(ed, ch, linewise);
+            MarkJump::SameBuffer
+        }
+        _ => MarkJump::Unset,
+    }
 }
 
 /// `true` when `op` records a `last_change` entry for dot-repeat purposes.

--- a/crates/hjkl-ex/src/listings.rs
+++ b/crates/hjkl-ex/src/listings.rs
@@ -55,24 +55,26 @@ fn display_register(text: &str) -> String {
 // ---- marks -----------------------------------------------------------------
 
 /// `:marks` — list every set mark with `(line, col)`. Lines are 1-based to
-/// match vim; cols are 0-based.
+/// match vim; cols are 0-based. Uppercase global marks include the buffer id.
 pub(crate) fn format_marks<H: Host>(
     editor: &hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
 ) -> String {
     let mut lines = vec!["--- Marks ---".to_string(), "mark  line  col".to_string()];
-    // 0.0.36: lowercase + uppercase marks share the unified
-    // `Editor::marks` map. `marks()` already iterates in BTreeMap
-    // (char-ordered) sequence, so no extra sort needed.
-    let entries: Vec<(char, usize, usize)> =
-        editor.marks().map(|(c, (r, col))| (c, r, col)).collect();
-    for (c, r, col) in entries {
-        lines.push(format!(" {c}    {:>4}  {col:>3}", r + 1));
+    // Lowercase (buffer-local) marks — from the unified `Editor::marks` map.
+    for (c, (r, col)) in editor.marks() {
+        if c.is_ascii_lowercase() || !c.is_ascii_alphabetic() {
+            lines.push(format!(" {c}    {:>4}  {:>3}", r + 1, col));
+        }
+    }
+    // Uppercase global marks — include buffer_id for cross-buffer context.
+    for (c, bid, r, col) in editor.global_marks_iter() {
+        lines.push(format!(" {c}    {:>4}  {:>3}  buf:{bid}", r + 1, col));
     }
     if let Some((r, col)) = editor.last_jump_back() {
-        lines.push(format!(" '    {:>4}  {col:>3}", r + 1));
+        lines.push(format!(" '    {:>4}  {:>3}", r + 1, col));
     }
     if let Some((r, col)) = editor.last_edit_pos() {
-        lines.push(format!(" .    {:>4}  {col:>3}", r + 1));
+        lines.push(format!(" .    {:>4}  {:>3}", r + 1, col));
     }
     if lines.len() == 2 {
         lines.push("(no marks set)".to_string());

--- a/crates/hjkl-vim-tui/tests/vim_fsm.rs
+++ b/crates/hjkl-vim-tui/tests/vim_fsm.rs
@@ -2727,9 +2727,14 @@ fn uppercase_mark_stored_under_uppercase_key() {
     let mut e = editor_with_rows(50, 20);
     e.jump_cursor(5, 3);
     run_keys(&mut e, "mA");
-    // 0.0.36: uppercase marks land in the unified `Editor::marks`
-    // map under the uppercase key — not under 'a'.
-    assert_eq!(e.mark('A'), Some((5, 3)));
+    // Uppercase marks now live in global_marks (cross-buffer), not the
+    // buffer-local `marks` map. The buffer_id defaults to 0 for a fresh editor.
+    let gm = e.global_mark('A');
+    assert!(gm.is_some(), "global mark 'A' should be set");
+    let (_bid, row, col) = gm.unwrap();
+    assert_eq!(row, 5);
+    assert_eq!(col, 3);
+    // Lowercase map is unaffected.
     assert!(e.mark('a').is_none());
 }
 
@@ -2845,6 +2850,75 @@ fn capital_mark_shifts_with_edit() {
     e.jump_cursor(0, 0);
     run_keys(&mut e, "'A");
     assert_eq!(e.cursor().0, 2);
+}
+
+// ── Global mark (cross-buffer) engine unit tests ───────────────────────────
+
+#[test]
+fn global_mark_same_buffer_jump_returns_same_buffer() {
+    let mut e = editor_with("alpha\nbeta\ngamma");
+    e.set_current_buffer_id(42);
+    e.jump_cursor(2, 1);
+    run_keys(&mut e, "mA");
+    // Verify the mark is stored in global_marks with the correct buffer_id.
+    let gm = e.global_mark('A');
+    assert!(gm.is_some());
+    let (bid, row, col) = gm.unwrap();
+    assert_eq!(bid, 42);
+    assert_eq!(row, 2);
+    assert_eq!(col, 1);
+    // Jump to same buffer — try_goto_mark_line returns SameBuffer.
+    e.jump_cursor(0, 0);
+    let jump = e.try_goto_mark_line('A');
+    assert_eq!(jump, hjkl_engine::MarkJump::SameBuffer);
+    assert_eq!(e.cursor().0, 2);
+}
+
+#[test]
+fn global_mark_cross_buffer_returns_cross_buffer() {
+    let mut e = editor_with("alpha\nbeta\ngamma");
+    // Set the mark with buffer_id=99.
+    e.set_current_buffer_id(99);
+    e.jump_cursor(1, 3);
+    run_keys(&mut e, "mB");
+    // Switch "current" buffer to a different id.
+    e.set_current_buffer_id(7);
+    // Jump should return CrossBuffer because 99 != 7.
+    let jump = e.try_goto_mark_char('B');
+    match jump {
+        hjkl_engine::MarkJump::CrossBuffer {
+            buffer_id,
+            row,
+            col,
+        } => {
+            assert_eq!(buffer_id, 99);
+            assert_eq!(row, 1);
+            assert_eq!(col, 3);
+        }
+        other => panic!("expected CrossBuffer, got {other:?}"),
+    }
+}
+
+#[test]
+fn global_mark_unset_returns_unset() {
+    let mut e = editor_with("hello");
+    let jump = e.try_goto_mark_line('Z');
+    assert_eq!(jump, hjkl_engine::MarkJump::Unset);
+}
+
+#[test]
+fn global_mark_shifts_after_edit_in_same_buffer() {
+    let mut e = editor_with("a\nb\nc\nd\ne");
+    e.set_current_buffer_id(1);
+    e.jump_cursor(4, 0);
+    run_keys(&mut e, "mC"); // global mark C at row 4
+    // Delete row 0 — mark should shift to row 3.
+    e.jump_cursor(0, 0);
+    run_keys(&mut e, "dd");
+    let (_, row, _) = e
+        .global_mark('C')
+        .expect("global mark C should still exist");
+    assert_eq!(row, 3, "global mark should shift up by 1 after dd at row 0");
 }
 
 #[test]

--- a/crates/hjkl-vim/src/normal.rs
+++ b/crates/hjkl-vim/src/normal.rs
@@ -601,10 +601,15 @@ fn handle_goto_mark<H: Host>(
     let Key::Char(c) = input.key else {
         return true;
     };
+    // CrossBuffer results are silently ignored here — the FSM has no
+    // mechanism to switch buffers. The app layer handles uppercase marks
+    // through chord_routing + apply_mark_jump. Lowercase/special marks
+    // always resolve in the same buffer. Uppercase marks that are in the
+    // same buffer (current_buffer_id matches) execute the jump normally.
     if linewise {
-        ed.goto_mark_line(c);
+        let _ = ed.try_goto_mark_line(c);
     } else {
-        ed.goto_mark_char(c);
+        let _ = ed.try_goto_mark_char(c);
     }
     true
 }


### PR DESCRIPTION
## Summary

- `mA`–`mZ` store global marks as `(buffer_id, row, col)` in a new `global_marks: BTreeMap<char, (u64, usize, usize)>` field on `Editor`
- `'A`/`` `A `` resolves through `try_goto_mark_line`/`try_goto_mark_char` → returns `MarkJump::CrossBuffer { buffer_id, row, col }` when the mark targets a different buffer; host calls `apply_mark_jump` which switches slot, positions cursor, syncs
- Same-buffer uppercase jumps return `MarkJump::SameBuffer` and execute immediately; unset marks return `MarkJump::Unset` (silent no-op)
- Stale mark (buffer closed): graceful `E474: mark references a closed buffer (id N)` toast, no crash
- `:marks` listing shows `buf:{id}` beside uppercase entries
- Lowercase marks (`ma`–`mz`) untouched — still per-buffer, no buffer switch

## Architecture

- `Editor::current_buffer_id` field updated by `switch_to` / `build_slot` / `buffer_delete` / `buffer_wipe` — no per-keystroke plumbing needed
- `shift_marks_after_edit` extended to shift `global_marks` belonging to the current buffer only
- `EditorSnapshot` VERSION bumped 4→5, `global_marks` field added for round-trip persistence
- `MarkJump` enum exported from `hjkl-engine` public surface
- Backward-compat `goto_mark_line`/`goto_mark_char` wrappers kept; new code uses `try_goto_mark_*`

## Test plan

- [ ] `global_mark_same_buffer_jump_returns_same_buffer` — `mA` at bid=42, `try_goto_mark_line('A')` returns `SameBuffer`, cursor moves
- [ ] `global_mark_cross_buffer_returns_cross_buffer` — set mark at bid=99, switch editor to bid=7, returns `CrossBuffer { buffer_id: 99, row, col }`
- [ ] `global_mark_unset_returns_unset` — `try_goto_mark_line('Z')` on fresh editor returns `Unset`
- [ ] `global_mark_shifts_after_edit_in_same_buffer` — mark at row 4 shifts to row 3 after `dd` at row 0
- [ ] `uppercase_mark_stored_under_uppercase_key` — `global_mark('A')` returns `Some(...)` after `mA`
- [ ] Full workspace: `cargo test --workspace` → 3326 passed, 0 failed