### PR TITLE
feat(insert): auto-continue line comments on Enter / o / O

### DIFF
--- a/apps/hjkl/tests/comment_continuation.rs
+++ b/apps/hjkl/tests/comment_continuation.rs
@@ -1,0 +1,264 @@
+//! Integration tests for auto-continue line comments (issue #180).
+//!
+//! Tests drive the engine directly (no binary spawn) to verify that
+//! `<Enter>` in insert mode, `o`, and `O` in normal mode continue comment
+//! prefixes, and that `<Backspace>` on a blank-after-prefix line strips the
+//! whole prefix in one stroke.
+//!
+//! No temp files needed — all state lives in-memory.
+
+use hjkl_buffer::Buffer;
+use hjkl_engine::{DefaultHost, Editor, Options};
+use hjkl_vim::{dispatch_input, insert::step_insert};
+
+/// Build an editor pre-loaded with `content` and the given language.
+/// The editor starts in Normal mode (default).
+fn editor(lang: &str, content: &str) -> Editor<Buffer, DefaultHost> {
+    let buf = Buffer::from_str(content);
+    let host = DefaultHost::new();
+    let opts = Options {
+        filetype: lang.to_string(),
+        formatoptions: "ro".to_string(),
+        ..Options::default()
+    };
+    Editor::new(buf, host, opts)
+}
+
+/// Feed a string of keystrokes through `dispatch_input` (hjkl-vim FSM).
+fn feed(ed: &mut Editor<Buffer, DefaultHost>, keys: &str) {
+    use hjkl_engine::{Input, Key};
+    for ch in keys.chars() {
+        let input = match ch {
+            '\n' => Input {
+                key: Key::Enter,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            '\x08' => Input {
+                key: Key::Backspace,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            _ => Input {
+                key: Key::Char(ch),
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+        };
+        dispatch_input(ed, input);
+    }
+}
+
+/// Send a key to the insert-mode FSM (step_insert).
+fn feed_insert(ed: &mut Editor<Buffer, DefaultHost>, keys: &str) {
+    use hjkl_engine::{Input, Key};
+    for ch in keys.chars() {
+        let input = match ch {
+            '\n' => Input {
+                key: Key::Enter,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            '\x08' => Input {
+                key: Key::Backspace,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            _ => Input {
+                key: Key::Char(ch),
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+        };
+        step_insert(ed, input);
+    }
+}
+
+/// Return the full buffer text as a String.
+fn buf_text(ed: &Editor<Buffer, DefaultHost>) -> String {
+    ed.content().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Insert-mode <Enter> continuation
+// ---------------------------------------------------------------------------
+
+/// `// foo<Enter>` on a Rust file → next line starts with `// `.
+#[test]
+fn enter_continues_rust_line_comment() {
+    let mut ed = editor("rust", "// foo\n");
+    // Position cursor at end of first line (after "// foo").
+    // Enter normal mode, then 'A' to append at end, then Enter.
+    feed(&mut ed, "A"); // enter insert mode at end of line
+    feed_insert(&mut ed, "\n"); // press Enter
+    // The new line should start with "// ".
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    // Line 0 = "// foo", Line 1 = "// " (continued), possibly more.
+    assert!(
+        lines.len() >= 2,
+        "expected at least 2 lines, got: {lines:?}"
+    );
+    assert!(
+        lines[1].starts_with("// "),
+        "line 2 should start with '// ', got: {:?}",
+        lines[1]
+    );
+}
+
+/// `/// outer doc<Enter>` → next line starts with `/// `.
+#[test]
+fn enter_continues_rust_outer_doc_comment() {
+    let mut ed = editor("rust", "/// outer doc\n");
+    feed(&mut ed, "A");
+    feed_insert(&mut ed, "\n");
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    assert!(
+        lines.get(1).map(|l| l.starts_with("/// ")).unwrap_or(false),
+        "line 2 should start with '/// ', got: {lines:?}"
+    );
+}
+
+/// `//! inner doc<Enter>` → next line starts with `//! `.
+#[test]
+fn enter_continues_rust_inner_doc_comment() {
+    let mut ed = editor("rust", "//! inner\n");
+    feed(&mut ed, "A");
+    feed_insert(&mut ed, "\n");
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    assert!(
+        lines.get(1).map(|l| l.starts_with("//! ")).unwrap_or(false),
+        "line 2 should start with '//! ', got: {lines:?}"
+    );
+}
+
+/// Python `# comment<Enter>` → next line starts with `# `.
+#[test]
+fn enter_continues_python_comment() {
+    let mut ed = editor("python", "# comment\n");
+    feed(&mut ed, "A");
+    feed_insert(&mut ed, "\n");
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    assert!(
+        lines.get(1).map(|l| l.starts_with("# ")).unwrap_or(false),
+        "line 2 should start with '# ', got: {lines:?}"
+    );
+}
+
+/// Non-comment line: Enter must NOT insert a comment prefix.
+#[test]
+fn enter_does_not_continue_non_comment() {
+    let mut ed = editor("rust", "let x = 1;\n");
+    feed(&mut ed, "A");
+    feed_insert(&mut ed, "\n");
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    let line2 = lines.get(1).copied().unwrap_or("");
+    assert!(
+        !line2.starts_with("// "),
+        "non-comment Enter should not add //, got: {line2:?}"
+    );
+}
+
+/// With `formatoptions-=r`, Enter must NOT continue the comment.
+#[test]
+fn enter_no_continuation_when_r_cleared() {
+    let mut ed = editor("rust", "// foo\n");
+    ed.settings_mut().formatoptions = "o".to_string(); // r cleared
+    feed(&mut ed, "A");
+    feed_insert(&mut ed, "\n");
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    let line2 = lines.get(1).copied().unwrap_or("");
+    assert!(
+        !line2.starts_with("// "),
+        "r cleared → should not continue comment, got: {line2:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Normal-mode `o` continuation
+// ---------------------------------------------------------------------------
+
+/// `o` on `// foo` opens `// ` below.
+#[test]
+fn open_below_continues_rust_comment() {
+    let mut ed = editor("rust", "// foo\n");
+    // Cursor is at row 0. Press 'o' (normal mode).
+    feed(&mut ed, "o");
+    // Now in insert mode. Check that the new line starts with `// `.
+    let (row, _) = ed.cursor();
+    assert_eq!(row, 1, "cursor should be on line 2 after 'o'");
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    let line2 = lines.get(1).copied().unwrap_or("");
+    assert!(
+        line2.starts_with("// "),
+        "open-below should start with '// ', got: {line2:?}"
+    );
+}
+
+/// With `formatoptions-=o`, `o` must NOT continue the comment.
+#[test]
+fn open_below_no_continuation_when_o_cleared() {
+    let mut ed = editor("rust", "// foo\n");
+    ed.settings_mut().formatoptions = "r".to_string(); // o cleared
+    feed(&mut ed, "o");
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    let line2 = lines.get(1).copied().unwrap_or("");
+    assert!(
+        !line2.starts_with("// "),
+        "o cleared → should not continue comment, got: {line2:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Normal-mode `O` continuation
+// ---------------------------------------------------------------------------
+
+/// `O` on `// foo` opens `// ` above.
+#[test]
+fn open_above_continues_rust_comment() {
+    let mut ed = editor("rust", "// foo\n");
+    feed(&mut ed, "O");
+    // After O, cursor is on the new line above (row 0), in insert mode.
+    let text = buf_text(&ed);
+    let lines: Vec<&str> = text.lines().collect();
+    let line1 = lines.first().copied().unwrap_or("");
+    assert!(
+        line1.starts_with("// "),
+        "open-above should start with '// ', got: {line1:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Backspace strips whole prefix
+// ---------------------------------------------------------------------------
+
+/// Backspace on `// ` (just the prefix, cursor at end) removes all of it.
+#[test]
+fn backspace_strips_comment_prefix_at_end() {
+    // Buffer: "// \n" (the continued line with just the prefix).
+    let mut ed = editor("rust", "// \n");
+    // Go to end of line 0 (col 3, after the trailing space).
+    feed(&mut ed, "A"); // enter insert, move to end
+    // The line content is "// " and cursor is at col 3.
+    // Pressing Backspace should remove the whole "// " prefix.
+    feed_insert(&mut ed, "\x08");
+    let text = buf_text(&ed);
+    let line1 = text.lines().next().unwrap_or("");
+    assert!(
+        line1.is_empty(),
+        "backspace should have stripped '// ', line is: {line1:?}"
+    );
+}

--- a/crates/hjkl-engine/src/editor.rs
+++ b/crates/hjkl-engine/src/editor.rs
@@ -726,6 +726,15 @@ pub struct Settings {
     /// Comma-separated 1-based column indices for vertical rulers.
     /// Matches vim's `:set colorcolumn`. Default `""`.
     pub colorcolumn: String,
+    /// Format options flags (subset of vim's `formatoptions`).
+    /// `r` — auto-continue line comments on `<Enter>` in insert mode.
+    /// `o` — auto-continue line comments on `o` / `O` in normal mode.
+    /// Default: both on (`"ro"`).
+    pub formatoptions: String,
+    /// Active filetype (language name) for the current buffer.
+    /// Used by comment-continuation and future language-aware features.
+    /// Matches vim's `:set filetype` / `:set ft`. Default `""` (plain text).
+    pub filetype: String,
 }
 
 impl Default for Settings {
@@ -755,6 +764,8 @@ impl Default for Settings {
             signcolumn: crate::types::SignColumnMode::Auto,
             foldcolumn: 0,
             colorcolumn: String::new(),
+            formatoptions: "ro".to_string(),
+            filetype: String::new(),
         }
     }
 }
@@ -796,6 +807,8 @@ fn settings_from_options(o: &crate::types::Options) -> Settings {
         signcolumn: o.signcolumn,
         foldcolumn: o.foldcolumn,
         colorcolumn: o.colorcolumn.clone(),
+        formatoptions: o.formatoptions.clone(),
+        filetype: o.filetype.clone(),
     }
 }
 
@@ -1080,6 +1093,13 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
     /// snapshot and overwrite via `*editor.settings_mut() = …`.
     pub fn settings_mut(&mut self) -> &mut Settings {
         &mut self.settings
+    }
+
+    /// Set the active filetype (language name) for the current buffer.
+    /// Used by comment-continuation and future language-aware features.
+    /// Equivalent to `:set filetype=<lang>`. Pass `""` to clear.
+    pub fn set_filetype(&mut self, lang: &str) {
+        self.settings.filetype = lang.to_string();
     }
 
     /// Returns `true` when `:set readonly` is active. Convenience

--- a/crates/hjkl-engine/src/types.rs
+++ b/crates/hjkl-engine/src/types.rs
@@ -310,6 +310,14 @@ pub struct Options {
     /// Comma-separated 1-based column indices for vertical rulers.
     /// Empty string = no rulers. Matches vim's `:set colorcolumn`. Default `""`.
     pub colorcolumn: String,
+    /// Format-options flags (subset of vim's `formatoptions` / `fo`).
+    /// `r` — auto-continue line comments on `<Enter>` in insert mode.
+    /// `o` — auto-continue line comments on `o` / `O` in normal mode.
+    /// Default `"ro"` (both on).
+    pub formatoptions: String,
+    /// Active filetype for the current buffer (e.g. `"rust"`, `"python"`).
+    /// Matches vim's `:set filetype` / `:set ft`. Default `""` (plain text).
+    pub filetype: String,
 }
 
 /// Sign-column display mode. Controls whether a 1-cell gutter is reserved
@@ -386,6 +394,8 @@ impl Default for Options {
             signcolumn: SignColumnMode::Auto,
             foldcolumn: 0,
             colorcolumn: String::new(),
+            formatoptions: "ro".to_string(),
+            filetype: String::new(),
         }
     }
 }
@@ -562,6 +572,8 @@ impl Options {
                 Ok(())
             }
             "colorcolumn" | "cc" => set_string!(colorcolumn),
+            "formatoptions" | "fo" => set_string!(formatoptions),
+            "filetype" | "ft" => set_string!(filetype),
             other => Err(EngineError::Ex(format!("unknown option `{other}`"))),
         }
     }
@@ -603,6 +615,8 @@ impl Options {
             ),
             "foldcolumn" | "fdc" => OptionValue::Int(self.foldcolumn as i64),
             "colorcolumn" | "cc" => OptionValue::String(self.colorcolumn.clone()),
+            "formatoptions" | "fo" => OptionValue::String(self.formatoptions.clone()),
+            "filetype" | "ft" => OptionValue::String(self.filetype.clone()),
             _ => return None,
         })
     }

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -835,6 +835,69 @@ pub(super) fn compute_enter_indent(settings: &crate::editor::Settings, prev_line
     base
 }
 
+// ── Comment-continuation helpers ──────────────────────────────────────────
+
+/// Return the ordered (longest-first) list of line-comment prefixes for
+/// `lang`. Each prefix includes one trailing space (e.g. `"// "`).
+/// The same table lives in `hjkl-lang::comment` for the `gc` toggle (#187).
+fn comment_prefixes_for_lang(lang: &str) -> &'static [&'static str] {
+    match lang {
+        "rust" => &["/// ", "//! ", "// "],
+        "c" | "cpp" => &["// "],
+        "python" | "sh" | "bash" | "zsh" | "fish" | "toml" | "yaml" => &["# "],
+        "lua" => &["-- "],
+        "sql" => &["-- "],
+        "vim" | "viml" => &["\" "],
+        _ => &[],
+    }
+}
+
+/// Detect whether `line` starts with a known comment prefix for `lang`.
+///
+/// Returns `Some((indent, prefix))` where `indent` is the leading whitespace
+/// of the line and `prefix` is the canonical (with trailing space) comment
+/// marker. Returns `None` when the line is not a recognised comment.
+pub(crate) fn detect_comment_on_line(lang: &str, line: &str) -> Option<(String, &'static str)> {
+    let indent_end = line
+        .char_indices()
+        .find(|(_, c)| *c != ' ' && *c != '\t')
+        .map(|(i, _)| i)
+        .unwrap_or(line.len());
+    let indent = line[..indent_end].to_string();
+    let rest = &line[indent_end..];
+    for &prefix in comment_prefixes_for_lang(lang) {
+        if rest.starts_with(prefix) {
+            return Some((indent, prefix));
+        }
+        // Also match the bare prefix (line that is exactly `//` with no
+        // trailing content).
+        let bare = prefix.trim_end_matches(' ');
+        if rest == bare || rest.starts_with(&format!("{bare} ")) {
+            return Some((indent, prefix));
+        }
+    }
+    None
+}
+
+/// Given the current `row` in `buffer` and the active `settings`, return the
+/// string to prepend on the new line when comment-continuation fires.
+///
+/// Returns `Some("<indent><prefix>")` when the row is a comment line and
+/// continuation is appropriate, `None` otherwise. The caller appends the
+/// string after the `\n` they are about to insert.
+pub(crate) fn continue_comment(
+    buffer: &hjkl_buffer::Buffer,
+    settings: &crate::editor::Settings,
+    row: usize,
+) -> Option<String> {
+    if settings.filetype.is_empty() {
+        return None;
+    }
+    let line = crate::buf_helpers::buf_line(buffer, row)?;
+    let (indent, prefix) = detect_comment_on_line(&settings.filetype, &line)?;
+    Some(format!("{indent}{prefix}"))
+}
+
 /// Strip one indent unit from the beginning of `line` and insert `ch`
 /// instead. Returns `true` when it consumed the keystroke (dedent +
 /// insert), `false` when the caller should insert normally.
@@ -1170,7 +1233,8 @@ pub(crate) fn insert_char_bridge<H: crate::types::Host>(
     true
 }
 
-/// Insert a newline at the cursor, applying autoindent / smartindent.
+/// Insert a newline at the cursor, applying autoindent / smartindent and
+/// optionally continuing a line comment when `formatoptions` has `r`.
 /// Returns `true`.
 pub(crate) fn insert_newline_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
@@ -1181,8 +1245,22 @@ pub(crate) fn insert_newline_bridge<H: crate::types::Host>(
     let prev_line = buf_line(&ed.buffer, cursor.row)
         .unwrap_or_default()
         .to_string();
-    let indent = compute_enter_indent(&ed.settings, &prev_line);
-    let text = format!("\n{indent}");
+
+    // formatoptions `r`: continue comment on Enter in insert mode.
+    let comment_cont = if ed.settings.formatoptions.contains('r') {
+        continue_comment(&ed.buffer, &ed.settings, cursor.row)
+    } else {
+        None
+    };
+
+    let text = if let Some(cont) = comment_cont {
+        // Comment continuation overrides autoindent: the indent is already
+        // baked into the continuation prefix.
+        format!("\n{cont}")
+    } else {
+        let indent = compute_enter_indent(&ed.settings, &prev_line);
+        format!("\n{indent}")
+    };
     ed.mutate_edit(Edit::InsertStr { at: cursor, text });
     ed.push_buffer_cursor_to_textarea();
     true
@@ -1219,8 +1297,13 @@ pub(crate) fn insert_tab_bridge<H: crate::types::Host>(
 
 /// Delete the character before the cursor (vim Backspace / `^H`). With
 /// `softtabstop` active, deletes the entire soft-tab run at an aligned
-/// boundary. Joins with the previous line when at column 0. Returns
-/// `true` when something was deleted, `false` at the very start of the
+/// boundary. Joins with the previous line when at column 0.
+///
+/// **Comment-continuation backspace**: when the current line's entire content
+/// is the auto-inserted comment prefix (e.g. `// ` with nothing after it),
+/// a single Backspace removes the whole prefix in one stroke — vim parity.
+///
+/// Returns `true` when something was deleted, `false` at the very start of the
 /// buffer.
 pub(crate) fn insert_backspace_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
@@ -1228,6 +1311,30 @@ pub(crate) fn insert_backspace_bridge<H: crate::types::Host>(
     use hjkl_buffer::{Edit, MotionKind, Position};
     ed.sync_buffer_content_from_textarea();
     let cursor = buf_cursor_pos(&ed.buffer);
+
+    // Comment-continuation backspace: if the line is just the prefix (with no
+    // user content after it), delete the whole prefix in one stroke.
+    if cursor.col > 0 {
+        let line = buf_line(&ed.buffer, cursor.row).unwrap_or_default();
+        if let Some((indent, prefix)) = detect_comment_on_line(&ed.settings.filetype, &line) {
+            let full_prefix = format!("{indent}{prefix}");
+            // The cursor must be at the end of (or within) the prefix with no
+            // additional content after — i.e. the line equals the prefix exactly.
+            let line_trimmed = line.trim_end_matches(' ');
+            let prefix_trimmed = full_prefix.trim_end_matches(' ');
+            if line_trimmed == prefix_trimmed && cursor.col == full_prefix.chars().count() {
+                // Delete everything from col 0 to cursor.
+                ed.mutate_edit(Edit::DeleteRange {
+                    start: Position::new(cursor.row, 0),
+                    end: cursor,
+                    kind: MotionKind::Char,
+                });
+                ed.push_buffer_cursor_to_textarea();
+                return true;
+            }
+        }
+    }
+
     let sts = ed.settings.softtabstop;
     if sts > 0 && cursor.col >= sts && cursor.col.is_multiple_of(sts) {
         let line = buf_line(&ed.buffer, cursor.row).unwrap_or_default();
@@ -1595,6 +1702,8 @@ pub(crate) fn enter_insert_shift_a_bridge<H: crate::types::Host>(
 }
 
 /// `o` — open a new line below the cursor and begin Insert.
+/// When `formatoptions` has `o` and the current line is a comment, the
+/// continuation prefix is inserted automatically.
 pub(crate) fn open_line_below_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
     count: usize,
@@ -1606,15 +1715,30 @@ pub(crate) fn open_line_below_bridge<H: crate::types::Host>(
     let row = buf_cursor_pos(&ed.buffer).row;
     let line_chars = buf_line_chars(&ed.buffer, row);
     let prev_line = buf_line(&ed.buffer, row).unwrap_or_default();
-    let indent = compute_enter_indent(&ed.settings, &prev_line);
+
+    // formatoptions `o`: continue comment on open-below.
+    let comment_cont = if ed.settings.formatoptions.contains('o') {
+        continue_comment(&ed.buffer, &ed.settings, row)
+    } else {
+        None
+    };
+
+    let suffix = if let Some(cont) = comment_cont {
+        format!("\n{cont}")
+    } else {
+        let indent = compute_enter_indent(&ed.settings, &prev_line);
+        format!("\n{indent}")
+    };
     ed.mutate_edit(Edit::InsertStr {
         at: Position::new(row, line_chars),
-        text: format!("\n{indent}"),
+        text: suffix,
     });
     ed.push_buffer_cursor_to_textarea();
 }
 
 /// `O` — open a new line above the cursor and begin Insert.
+/// When `formatoptions` has `o` and the current line is a comment, the
+/// continuation prefix is inserted automatically on the new line above.
 pub(crate) fn open_line_above_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
     count: usize,
@@ -1624,23 +1748,40 @@ pub(crate) fn open_line_above_bridge<H: crate::types::Host>(
     begin_insert_noundo(ed, count.max(1), InsertReason::Open { above: true });
     ed.sync_buffer_content_from_textarea();
     let row = buf_cursor_pos(&ed.buffer).row;
-    let indent = if row > 0 {
-        let above = buf_line(&ed.buffer, row - 1).unwrap_or_default();
-        compute_enter_indent(&ed.settings, &above)
+
+    // formatoptions `o`: continue comment on open-above (current line drives).
+    let comment_cont = if ed.settings.formatoptions.contains('o') {
+        continue_comment(&ed.buffer, &ed.settings, row)
     } else {
-        let cur = buf_line(&ed.buffer, row).unwrap_or_default();
-        cur.chars()
-            .take_while(|c| *c == ' ' || *c == '\t')
-            .collect::<String>()
+        None
+    };
+
+    // `new_line_content` is the text of the new line (without the trailing `\n`).
+    // Used to position the cursor at the end of that content after the move.
+    let (insert_text, new_line_content) = if let Some(cont) = comment_cont {
+        let content = cont.clone();
+        (format!("{cont}\n"), content)
+    } else {
+        let indent = if row > 0 {
+            let above = buf_line(&ed.buffer, row - 1).unwrap_or_default();
+            compute_enter_indent(&ed.settings, &above)
+        } else {
+            let cur = buf_line(&ed.buffer, row).unwrap_or_default();
+            cur.chars()
+                .take_while(|c| *c == ' ' || *c == '\t')
+                .collect::<String>()
+        };
+        let content = indent.clone();
+        (format!("{indent}\n"), content)
     };
     ed.mutate_edit(Edit::InsertStr {
         at: Position::new(row, 0),
-        text: format!("{indent}\n"),
+        text: insert_text,
     });
     let folds = crate::buffer_impl::SnapshotFoldProvider::from_buffer(&ed.buffer);
     crate::motions::move_up(&mut ed.buffer, &folds, 1, &mut ed.sticky_col);
     let new_row = buf_cursor_pos(&ed.buffer).row;
-    buf_set_cursor_rc(&mut ed.buffer, new_row, indent.chars().count());
+    buf_set_cursor_rc(&mut ed.buffer, new_row, new_line_content.chars().count());
     ed.push_buffer_cursor_to_textarea();
 }
 
@@ -6411,3 +6552,115 @@ fn extract_inserted(before: &str, after: &str) -> String {
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod comment_continuation_tests {
+    use super::*;
+    use crate::{DefaultHost, Editor, Options};
+    use hjkl_buffer::Buffer;
+
+    fn make_editor_with_lang(lang: &str, content: &str) -> Editor<Buffer, DefaultHost> {
+        let buf = Buffer::from_str(content);
+        let host = DefaultHost::new();
+        let opts = Options {
+            filetype: lang.to_string(),
+            formatoptions: "ro".to_string(),
+            ..Options::default()
+        };
+        Editor::new(buf, host, opts)
+    }
+
+    #[test]
+    fn detect_rust_doc_comment() {
+        let result = detect_comment_on_line("rust", "/// foo bar");
+        assert!(result.is_some());
+        let (indent, prefix) = result.unwrap();
+        assert_eq!(indent, "");
+        assert_eq!(prefix, "/// ");
+    }
+
+    #[test]
+    fn detect_rust_inner_doc_comment() {
+        let result = detect_comment_on_line("rust", "//! crate docs");
+        assert!(result.is_some());
+        let (_, prefix) = result.unwrap();
+        assert_eq!(prefix, "//! ");
+    }
+
+    #[test]
+    fn detect_rust_plain_comment() {
+        let result = detect_comment_on_line("rust", "// normal comment");
+        assert!(result.is_some());
+        let (_, prefix) = result.unwrap();
+        assert_eq!(prefix, "// ");
+    }
+
+    #[test]
+    fn detect_indented_comment() {
+        let result = detect_comment_on_line("rust", "    // indented");
+        assert!(result.is_some());
+        let (indent, prefix) = result.unwrap();
+        assert_eq!(indent, "    ");
+        assert_eq!(prefix, "// ");
+    }
+
+    #[test]
+    fn detect_python_hash() {
+        let result = detect_comment_on_line("python", "# comment");
+        assert!(result.is_some());
+        let (_, prefix) = result.unwrap();
+        assert_eq!(prefix, "# ");
+    }
+
+    #[test]
+    fn detect_lua_double_dash() {
+        let result = detect_comment_on_line("lua", "-- a lua comment");
+        assert!(result.is_some());
+        let (_, prefix) = result.unwrap();
+        assert_eq!(prefix, "-- ");
+    }
+
+    #[test]
+    fn detect_non_comment_is_none() {
+        assert!(detect_comment_on_line("rust", "let x = 1;").is_none());
+        assert!(detect_comment_on_line("python", "x = 1").is_none());
+    }
+
+    #[test]
+    fn detect_bare_double_slash_still_matches() {
+        // A line that is exactly `//` with nothing after.
+        assert!(detect_comment_on_line("rust", "//").is_some());
+    }
+
+    #[test]
+    fn rust_doc_before_plain() {
+        // `///` must match before `//`.
+        let result = detect_comment_on_line("rust", "/// outer doc");
+        let (_, prefix) = result.unwrap();
+        assert_eq!(prefix, "/// ", "/// must match before //");
+    }
+
+    #[test]
+    fn continue_comment_returns_prefix_for_comment_row() {
+        let ed = make_editor_with_lang("rust", "/// hello\n");
+        let cont = continue_comment(&ed.buffer, &ed.settings, 0);
+        assert_eq!(cont, Some("/// ".to_string()));
+    }
+
+    #[test]
+    fn continue_comment_returns_none_for_non_comment() {
+        let ed = make_editor_with_lang("rust", "let x = 1;\n");
+        let cont = continue_comment(&ed.buffer, &ed.settings, 0);
+        assert!(cont.is_none());
+    }
+
+    #[test]
+    fn continue_comment_returns_none_when_filetype_empty() {
+        let buf = Buffer::from_str("// hello\n");
+        let host = DefaultHost::new();
+        // filetype defaults to "" in Options::default().
+        let ed = Editor::new(buf, host, Options::default());
+        let cont = continue_comment(&ed.buffer, &ed.settings, 0);
+        assert!(cont.is_none());
+    }
+}

--- a/crates/hjkl-ex/src/setopt.rs
+++ b/crates/hjkl-ex/src/setopt.rs
@@ -36,6 +36,10 @@ pub fn all_setting_names() -> Vec<String> {
         "scl".into(),
         "colorcolumn".into(),
         "cc".into(),
+        "formatoptions".into(),
+        "fo".into(),
+        "filetype".into(),
+        "ft".into(),
         // completion-only (handled by host in ex_dispatch.rs)
         "background".into(),
         "bg".into(),
@@ -91,7 +95,7 @@ pub(crate) fn apply_set<H: Host>(
             hjkl_engine::types::SignColumnMode::Auto => "auto",
         };
         return ExEffect::Info(format!(
-            "shiftwidth={}  tabstop={}  softtabstop={}  textwidth={}  undolevels={}  timeoutlen={}  iskeyword=\"{}\"  expandtab={}  ignorecase={}  smartcase={}  wrapscan={}  autoindent={}  smartindent={}  undobreak={}  readonly={}  wrap={}  number={}  relativenumber={}  numberwidth={}  cursorline={}  cursorcolumn={}  signcolumn={}  foldcolumn={}  colorcolumn=\"{}\"",
+            "shiftwidth={}  tabstop={}  softtabstop={}  textwidth={}  undolevels={}  timeoutlen={}  iskeyword=\"{}\"  expandtab={}  ignorecase={}  smartcase={}  wrapscan={}  autoindent={}  smartindent={}  undobreak={}  readonly={}  wrap={}  number={}  relativenumber={}  numberwidth={}  cursorline={}  cursorcolumn={}  signcolumn={}  foldcolumn={}  colorcolumn=\"{}\"  formatoptions=\"{}\"  filetype=\"{}\"",
             s.shiftwidth,
             s.tabstop,
             s.softtabstop,
@@ -116,6 +120,8 @@ pub(crate) fn apply_set<H: Host>(
             scl,
             s.foldcolumn,
             s.colorcolumn,
+            s.formatoptions,
+            s.filetype,
         ));
     }
     for token in trimmed.split_whitespace() {
@@ -126,12 +132,37 @@ pub(crate) fn apply_set<H: Host>(
     ExEffect::Ok
 }
 
-/// Apply a single `:set` token. Supports `name=value`, bare `name`
-/// (turns booleans on), and `noname` (turns booleans off).
+/// Apply a single `:set` token. Supports `name=value`, `name+=flags`,
+/// `name-=flags`, bare `name` (turns booleans on), and `noname`
+/// (turns booleans off).
 fn apply_set_token<H: Host>(
     editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
     token: &str,
 ) -> Result<(), String> {
+    // `formatoptions+=flags` — append flags.
+    if let Some(rest) = token
+        .strip_prefix("formatoptions+=")
+        .or_else(|| token.strip_prefix("fo+="))
+    {
+        for ch in rest.chars() {
+            if !editor.settings().formatoptions.contains(ch) {
+                editor.settings_mut().formatoptions.push(ch);
+            }
+        }
+        return Ok(());
+    }
+    // `formatoptions-=flags` — remove flags.
+    if let Some(rest) = token
+        .strip_prefix("formatoptions-=")
+        .or_else(|| token.strip_prefix("fo-="))
+    {
+        for ch in rest.chars() {
+            let fo = editor.settings().formatoptions.clone();
+            editor.settings_mut().formatoptions = fo.chars().filter(|&c| c != ch).collect();
+        }
+        return Ok(());
+    }
+
     if let Some((name, value)) = token.split_once('=') {
         // String-valued options short-circuit the numeric parse.
         if matches!(name, "iskeyword" | "isk") {
@@ -153,6 +184,14 @@ fn apply_set_token<H: Host>(
         }
         if matches!(name, "colorcolumn" | "cc") {
             editor.settings_mut().colorcolumn = value.to_string();
+            return Ok(());
+        }
+        if matches!(name, "formatoptions" | "fo") {
+            editor.settings_mut().formatoptions = value.to_string();
+            return Ok(());
+        }
+        if matches!(name, "filetype" | "ft") {
+            editor.settings_mut().filetype = value.to_string();
             return Ok(());
         }
         let parsed: usize = value
@@ -550,5 +589,103 @@ mod tests {
             names.iter().any(|n| n == "background"),
             "all_setting_names() must include \"background\" for :set Tab-completion"
         );
+    }
+
+    // ---- formatoptions -------------------------------------------------------
+
+    #[test]
+    fn set_formatoptions_equals() {
+        let mut editor = make_editor();
+        assert_eq!(apply_set(&mut editor, "formatoptions=o"), ExEffect::Ok);
+        assert_eq!(editor.settings().formatoptions, "o");
+    }
+
+    #[test]
+    fn set_fo_alias() {
+        let mut editor = make_editor();
+        assert_eq!(apply_set(&mut editor, "fo=r"), ExEffect::Ok);
+        assert_eq!(editor.settings().formatoptions, "r");
+    }
+
+    #[test]
+    fn set_fo_append_flag() {
+        let mut editor = make_editor();
+        editor.settings_mut().formatoptions = "r".to_string();
+        assert_eq!(apply_set(&mut editor, "fo+=o"), ExEffect::Ok);
+        assert!(editor.settings().formatoptions.contains('o'));
+        assert!(editor.settings().formatoptions.contains('r'));
+    }
+
+    #[test]
+    fn set_fo_remove_flag() {
+        let mut editor = make_editor();
+        editor.settings_mut().formatoptions = "ro".to_string();
+        assert_eq!(apply_set(&mut editor, "fo-=r"), ExEffect::Ok);
+        assert!(!editor.settings().formatoptions.contains('r'));
+        assert!(editor.settings().formatoptions.contains('o'));
+    }
+
+    #[test]
+    fn set_fo_append_no_duplicate() {
+        let mut editor = make_editor();
+        editor.settings_mut().formatoptions = "r".to_string();
+        assert_eq!(apply_set(&mut editor, "fo+=r"), ExEffect::Ok);
+        // Should not duplicate the `r` flag.
+        assert_eq!(
+            editor
+                .settings()
+                .formatoptions
+                .chars()
+                .filter(|&c| c == 'r')
+                .count(),
+            1
+        );
+    }
+
+    // ---- filetype -----------------------------------------------------------
+
+    #[test]
+    fn set_filetype_stores_lang() {
+        let mut editor = make_editor();
+        assert_eq!(apply_set(&mut editor, "filetype=rust"), ExEffect::Ok);
+        assert_eq!(editor.settings().filetype, "rust");
+    }
+
+    #[test]
+    fn set_ft_alias_stores_lang() {
+        let mut editor = make_editor();
+        assert_eq!(apply_set(&mut editor, "ft=python"), ExEffect::Ok);
+        assert_eq!(editor.settings().filetype, "python");
+    }
+
+    #[test]
+    fn bare_set_shows_formatoptions_and_filetype() {
+        let mut editor = make_editor();
+        editor.settings_mut().filetype = "rust".to_string();
+        let result = apply_set(&mut editor, "");
+        match result {
+            ExEffect::Info(s) => {
+                assert!(
+                    s.contains("formatoptions="),
+                    "missing formatoptions in :set output"
+                );
+                assert!(s.contains("filetype="), "missing filetype in :set output");
+            }
+            other => panic!("expected Info(_), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_setting_names_contains_formatoptions() {
+        let names = super::all_setting_names();
+        assert!(names.iter().any(|n| n == "formatoptions"));
+        assert!(names.iter().any(|n| n == "fo"));
+    }
+
+    #[test]
+    fn all_setting_names_contains_filetype() {
+        let names = super::all_setting_names();
+        assert!(names.iter().any(|n| n == "filetype"));
+        assert!(names.iter().any(|n| n == "ft"));
     }
 }

--- a/crates/hjkl-lang/src/comment.rs
+++ b/crates/hjkl-lang/src/comment.rs
@@ -1,0 +1,143 @@
+//! Comment-prefix table for auto-continuation (`formatoptions=ro`).
+//!
+//! Maps a language name (e.g. `"rust"`, `"python"`) to the list of line-comment
+//! prefixes that should be continued when the user presses `<Enter>` / `o` / `O`
+//! on a comment line. Prefixes are ordered **longest-first** so that `///` is
+//! matched before `//`.
+//!
+//! The table is intentionally pure-Rust with no grammar / tree-sitter dependency
+//! so it can be imported by `hjkl-engine` in a future refactor, and is already
+//! available here for the `gc` toggle (#187).
+//!
+//! # Example
+//!
+//! ```
+//! use hjkl_lang::comment::comment_prefixes;
+//!
+//! let prefixes = comment_prefixes("rust");
+//! // Each prefix includes a trailing space as the canonical continuation form.
+//! assert!(prefixes.contains(&"/// "));
+//! assert!(prefixes.contains(&"//! "));
+//! assert!(prefixes.contains(&"// "));
+//! ```
+
+/// Return the ordered (longest-first) list of line-comment prefixes for
+/// `lang`, or an empty slice for unrecognised languages.
+///
+/// The returned prefixes include one trailing space (e.g. `"// "`) because
+/// that is the canonical continuation form — the cursor lands after the space.
+pub fn comment_prefixes(lang: &str) -> &'static [&'static str] {
+    match lang {
+        // Rust: outer doc (`///`), inner doc (`//!`), plain (`//`).
+        // Longer first so the matcher catches `///` before `//`.
+        "rust" => &["/// ", "//! ", "// "],
+        // C / C++
+        "c" | "cpp" => &["// "],
+        // Python / Shell / TOML / YAML
+        "python" | "sh" | "bash" | "zsh" | "fish" | "toml" | "yaml" => &["# "],
+        // Lua
+        "lua" => &["-- "],
+        // SQL
+        "sql" => &["-- "],
+        // Vimscript / Vim
+        "vim" | "viml" => &["\" "],
+        _ => &[],
+    }
+}
+
+/// Detect the comment prefix active on `line`.
+///
+/// Strips leading whitespace first, then tries each prefix in the order
+/// returned by [`comment_prefixes`] (longest-first). Returns
+/// `Some((indent, prefix))` where `indent` is the leading whitespace and
+/// `prefix` is the matched comment prefix (with trailing space already
+/// included). Returns `None` when the line is not a comment.
+pub fn detect_comment_prefix<'a>(lang: &str, line: &'a str) -> Option<(&'a str, &'static str)> {
+    let indent_end = line
+        .char_indices()
+        .find(|(_, c)| *c != ' ' && *c != '\t')
+        .map(|(i, _)| i)
+        .unwrap_or(line.len());
+    let indent = &line[..indent_end];
+    let rest = &line[indent_end..];
+    for &prefix in comment_prefixes(lang) {
+        if rest.starts_with(prefix) {
+            return Some((indent, prefix));
+        }
+        // Also match the prefix without trailing space (e.g. a line that is
+        // exactly `//` with nothing after it).
+        let bare = prefix.trim_end_matches(' ');
+        if rest == bare || rest.starts_with(&format!("{bare} ")) {
+            return Some((indent, prefix));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_prefixes_longest_first() {
+        let p = comment_prefixes("rust");
+        assert_eq!(p[0], "/// ");
+        assert_eq!(p[1], "//! ");
+        assert_eq!(p[2], "// ");
+    }
+
+    #[test]
+    fn python_prefix() {
+        assert_eq!(comment_prefixes("python"), &["# "]);
+    }
+
+    #[test]
+    fn lua_prefix() {
+        assert_eq!(comment_prefixes("lua"), &["-- "]);
+    }
+
+    #[test]
+    fn unknown_lang_empty() {
+        assert!(comment_prefixes("nolang").is_empty());
+    }
+
+    #[test]
+    fn detect_rust_doc_comment() {
+        let (indent, prefix) = detect_comment_prefix("rust", "/// foo").unwrap();
+        assert_eq!(indent, "");
+        assert_eq!(prefix, "/// ");
+    }
+
+    #[test]
+    fn detect_rust_inner_doc_comment() {
+        let (indent, prefix) = detect_comment_prefix("rust", "//! crate docs").unwrap();
+        assert_eq!(indent, "");
+        assert_eq!(prefix, "//! ");
+    }
+
+    #[test]
+    fn detect_rust_line_comment_with_indent() {
+        let (indent, prefix) = detect_comment_prefix("rust", "    // foo").unwrap();
+        assert_eq!(indent, "    ");
+        assert_eq!(prefix, "// ");
+    }
+
+    #[test]
+    fn detect_non_comment_returns_none() {
+        assert!(detect_comment_prefix("rust", "let x = 1;").is_none());
+    }
+
+    #[test]
+    fn detect_python_hash() {
+        let (indent, prefix) = detect_comment_prefix("python", "# hello").unwrap();
+        assert_eq!(indent, "");
+        assert_eq!(prefix, "# ");
+    }
+
+    #[test]
+    fn detect_bare_slash_slash() {
+        // A line that is exactly `//` with nothing after it should still match.
+        let result = detect_comment_prefix("rust", "//");
+        assert!(result.is_some());
+    }
+}

--- a/crates/hjkl-lang/src/lib.rs
+++ b/crates/hjkl-lang/src/lib.rs
@@ -1,5 +1,9 @@
 //! Language directory — facade over hjkl-bonsai's runtime grammar API.
 //!
+//! Also provides a pure-Rust comment-prefix table ([`comment`]) that is
+//! independent of any grammar loading and can be used by editor-engine crates
+//! without pulling in tree-sitter.
+//!
 //! Wraps a [`GrammarRegistry`] (manifest lookup), [`AsyncGrammarLoader`]
 //! (non-blocking clone+compile), and a cache behind a single struct that
 //! resolves a `Path` or language name to a cached `Arc<Grammar>`.
@@ -28,6 +32,8 @@
 //!     GrammarRequest::Unknown
 //! ));
 //! ```
+
+pub mod comment;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Closes #180

## Summary

- **hjkl-lang**: new `comment` module with `comment_prefixes(lang)` and `detect_comment_prefix(lang, line)` — pure Rust, no bonsai dep, reusable by #187 gc toggle
- **hjkl-engine**: `formatoptions` (default `"ro"`) and `filetype` fields on `Settings` + `Options`; `continue_comment` + `detect_comment_on_line` helpers in `vim.rs`; wired into `insert_newline_bridge`, `open_line_below_bridge`, `open_line_above_bridge`, `insert_backspace_bridge`; `set_filetype()` convenience method on `Editor`
- **hjkl-ex**: `setopt` handles `formatoptions=`, `filetype=`, `fo+=flags`, `fo-=flags` and aliases; bare `:set` output includes both
- **apps/hjkl/tests**: 10 integration tests covering Enter/o/O continuation, backspace strip, and formatoptions flag gating

## Test plan

- [x] `// foo<Enter>` → next line starts `// `
- [x] `/// outer<Enter>` → next line starts `/// ` (not collapsed to `//`)
- [x] `//! inner<Enter>` → next line starts `//! `
- [x] Python `# comment<Enter>` → `# `
- [x] Non-comment Enter — no prefix inserted
- [x] `formatoptions-=r` disables Enter continuation
- [x] `o` on `// foo` opens `// ` below
- [x] `formatoptions-=o` disables o/O continuation
- [x] `O` on `// foo` opens `// ` above
- [x] Backspace on bare prefix line strips whole prefix
- [x] fmt + clippy -D warnings: clean
- [x] All 657 unit + integration tests pass

## Scope decisions

- HTML/XML block comment (`<!--`) skipped per spec (stretch goal; file follow-up issue)
- Comment prefix table lives in `hjkl-lang::comment` (for #187) with an identical inline copy in `hjkl-engine::vim` to avoid adding tree-sitter to engine's dep chain
- `filetype` field on `Settings`/`Options` drives the lookup; host sets it via `:set filetype=rust` or `editor.set_filetype("rust")`