### PR TITLE
feat(editor): gc / gcc comment toggle operator + :comment / :uncomment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,7 @@ version = "0.27.0"
 dependencies = [
  "bitflags 2.11.1",
  "hjkl-buffer",
+ "hjkl-lang",
  "proptest",
  "regex",
  "serde",
@@ -2422,6 +2423,7 @@ version = "0.27.0"
 dependencies = [
  "hjkl-buffer",
  "hjkl-engine",
+ "hjkl-lang",
  "regex",
  "tempfile",
 ]

--- a/apps/hjkl/src/app/engine_actions.rs
+++ b/apps/hjkl/src/app/engine_actions.rs
@@ -146,6 +146,12 @@ impl App {
                                 self.open_filter_prompt(top_row, bot_row);
                                 return;
                             }
+                            hjkl_vim::OperatorKind::Comment => {
+                                // Visual-block gc: toggle comments on the row range.
+                                self.active_mut()
+                                    .editor
+                                    .toggle_comment_range(top_row, bot_row);
+                            }
                             _ => return,
                         }
                         // Exit visual mode after the op (except Change above).
@@ -224,6 +230,11 @@ impl App {
                                 );
                                 self.open_filter_prompt(min_r, max_r);
                                 return;
+                            }
+                            hjkl_vim::OperatorKind::Comment => {
+                                // Visual-charwise gc: toggle comments on the row range.
+                                let (min_r, max_r) = (start.0.min(end.0), start.0.max(end.0));
+                                self.active_mut().editor.toggle_comment_range(min_r, max_r);
                             }
                             _ => return,
                         }
@@ -324,6 +335,12 @@ impl App {
                                 );
                                 self.open_filter_prompt(top_row, bot_row);
                                 return;
+                            }
+                            hjkl_vim::OperatorKind::Comment => {
+                                // Visual-line gc: toggle comments on the row range.
+                                self.active_mut()
+                                    .editor
+                                    .toggle_comment_range(top_row, bot_row);
                             }
                             _ => return,
                         }

--- a/apps/hjkl/src/app/event_loop.rs
+++ b/apps/hjkl/src/app/event_loop.rs
@@ -64,6 +64,7 @@ pub(crate) fn op_kind_to_operator(k: hjkl_vim::OperatorKind) -> hjkl_engine::Ope
         hjkl_vim::OperatorKind::Reflow => hjkl_engine::Operator::Reflow,
         hjkl_vim::OperatorKind::AutoIndent => hjkl_engine::Operator::AutoIndent,
         hjkl_vim::OperatorKind::Filter => hjkl_engine::Operator::Filter,
+        hjkl_vim::OperatorKind::Comment => hjkl_engine::Operator::Comment,
     }
 }
 

--- a/apps/hjkl/src/app/tests/mod.rs
+++ b/apps/hjkl/src/app/tests/mod.rs
@@ -20,6 +20,7 @@ fn op_kind_to_operator(k: hjkl_vim::OperatorKind) -> hjkl_engine::Operator {
         hjkl_vim::OperatorKind::Reflow => hjkl_engine::Operator::Reflow,
         hjkl_vim::OperatorKind::AutoIndent => hjkl_engine::Operator::AutoIndent,
         hjkl_vim::OperatorKind::Filter => hjkl_engine::Operator::Filter,
+        hjkl_vim::OperatorKind::Comment => hjkl_engine::Operator::Comment,
     }
 }
 

--- a/crates/hjkl-engine/Cargo.toml
+++ b/crates/hjkl-engine/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1"
 # Ratatui + crossterm adapter surface lives in `hjkl-engine-tui` (#162 phase 3).
 # `serde` is optional; wasm / no_std hosts opt out via `default-features = false`.
 hjkl-buffer.workspace = true
+hjkl-lang.workspace = true
 bitflags = "2"
 regex = "1"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/hjkl-engine/src/editor.rs
+++ b/crates/hjkl-engine/src/editor.rs
@@ -735,6 +735,15 @@ pub struct Settings {
     /// Used by comment-continuation and future language-aware features.
     /// Matches vim's `:set filetype` / `:set ft`. Default `""` (plain text).
     pub filetype: String,
+    /// Override comment-string for the current buffer.
+    ///
+    /// When non-empty, used by `toggle_comment_range` instead of the
+    /// per-filetype default from `hjkl_lang::comment::commentstring_for_lang`.
+    /// Follows vim's `:set commentstring=…` — use `%s` as the text placeholder
+    /// (e.g. `"// %s"`) for compatibility; the toggle strips/inserts only the
+    /// prefix/suffix portion (before/after `%s`).  An empty string means "use
+    /// the filetype default".  Default `""`.
+    pub commentstring: String,
 }
 
 impl Default for Settings {
@@ -766,6 +775,7 @@ impl Default for Settings {
             colorcolumn: String::new(),
             formatoptions: "ro".to_string(),
             filetype: String::new(),
+            commentstring: String::new(),
         }
     }
 }
@@ -809,6 +819,7 @@ fn settings_from_options(o: &crate::types::Options) -> Settings {
         colorcolumn: o.colorcolumn.clone(),
         formatoptions: o.formatoptions.clone(),
         filetype: o.filetype.clone(),
+        commentstring: String::new(),
     }
 }
 
@@ -3399,6 +3410,136 @@ impl<H: crate::types::Host> Editor<hjkl_buffer::Buffer, H> {
         self.force_normal();
 
         Ok(())
+    }
+
+    // ─── Comment toggle (#187) ───────────────────────────────────────────────
+
+    /// Toggle line comments on rows `top_row..=bot_row` (0-based, inclusive).
+    ///
+    /// **Algorithm** (vim-commentary parity):
+    ///
+    /// 1. Determine the comment marker(s) for the active filetype.
+    ///    Priority: `settings.commentstring` (`:set commentstring=…`) → per-filetype
+    ///    default from `hjkl_lang::comment::commentstring_for_lang` → no-op.
+    /// 2. Scan non-blank lines.  If every non-blank line is already commented →
+    ///    strip the comment marker from each.  Otherwise → add it to all non-blank
+    ///    lines.
+    /// 3. Blank / whitespace-only lines are skipped (no marker added or removed).
+    /// 4. The marker is inserted AFTER the leading whitespace (indent-preserving).
+    /// 5. The entire operation is a single undo step.
+    ///
+    /// For block-comment languages (HTML, CSS) each line is individually wrapped
+    /// as `start text end` (per-line block style, not one multi-line block).
+    ///
+    /// `top_row` and `bot_row` are clamped to the buffer's valid row range.
+    pub fn toggle_comment_range(&mut self, top_row: usize, bot_row: usize) {
+        use hjkl_lang::comment::commentstring_for_lang;
+
+        let lang = self.settings.filetype.clone();
+
+        // Resolve the comment markers.
+        // If `settings.commentstring` is set (non-empty) parse `start %s end`
+        // from it; otherwise fall back to the filetype table.
+        let (start, end) = if !self.settings.commentstring.is_empty() {
+            let cs = &self.settings.commentstring;
+            if let Some(idx) = cs.find("%s") {
+                let s = cs[..idx].trim_end().to_string();
+                let e_raw = cs[idx + 2..].trim_start();
+                let e: Option<String> = if e_raw.is_empty() {
+                    None
+                } else {
+                    Some(e_raw.to_string())
+                };
+                (s, e)
+            } else {
+                // No %s placeholder — treat the whole string as start marker.
+                (cs.clone(), None)
+            }
+        } else {
+            match commentstring_for_lang(&lang) {
+                Some((s, e)) => (s.to_string(), e.map(|v| v.to_string())),
+                None => return, // no known comment syntax → no-op
+            }
+        };
+
+        let row_count = buf_row_count(&self.buffer);
+        let top = top_row.min(row_count.saturating_sub(1));
+        let bot = bot_row.min(row_count.saturating_sub(1));
+
+        // Collect all lines in the range.
+        let lines: Vec<String> = (top..=bot)
+            .map(|r| buf_line(&self.buffer, r).unwrap_or_default())
+            .collect();
+
+        // Check whether every non-blank line is already commented.
+        let all_commented = lines.iter().all(|line| {
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() {
+                return true; // blank lines don't count against "all commented"
+            }
+            if let Some(ref end_marker) = end {
+                // Block style: line starts with start and ends with end.
+                trimmed.starts_with(start.as_str())
+                    && line.trim_end().ends_with(end_marker.as_str())
+            } else {
+                trimmed.starts_with(start.as_str())
+            }
+        });
+
+        let mut new_lines: Vec<String> = Vec::with_capacity(lines.len());
+        for line in &lines {
+            let trimmed = line.trim_start();
+            if trimmed.is_empty() {
+                // Blank line — leave as-is.
+                new_lines.push(line.clone());
+                continue;
+            }
+            let indent_len = line.len() - trimmed.len();
+            let indent = &line[..indent_len];
+
+            if all_commented {
+                // Uncomment: strip exactly one occurrence of start (+ optional space).
+                if let Some(after_start) = trimmed.strip_prefix(start.as_str()) {
+                    // Strip one leading space after the marker if present.
+                    let after_space = after_start.strip_prefix(' ').unwrap_or(after_start);
+                    // For block style also strip the trailing end marker.
+                    let text = if let Some(ref end_marker) = end {
+                        after_space
+                            .trim_end()
+                            .strip_suffix(end_marker.as_str())
+                            .map(|s| s.trim_end())
+                            .unwrap_or(after_space)
+                    } else {
+                        after_space
+                    };
+                    new_lines.push(format!("{indent}{text}"));
+                } else {
+                    new_lines.push(line.clone());
+                }
+            } else {
+                // Comment: insert marker after indent.
+                let commented = if let Some(ref end_marker) = end {
+                    format!("{indent}{start} {trimmed} {end_marker}")
+                } else {
+                    format!("{indent}{start} {trimmed}")
+                };
+                new_lines.push(commented);
+            }
+        }
+
+        // Replace the row range in the buffer — single undo step.
+        self.push_undo();
+        let row_count_after = buf_row_count(&self.buffer);
+        let all_before: Vec<String> = (0..top)
+            .map(|r| buf_line(&self.buffer, r).unwrap_or_default())
+            .collect();
+        let all_after: Vec<String> = ((bot + 1)..row_count_after)
+            .map(|r| buf_line(&self.buffer, r).unwrap_or_default())
+            .collect();
+        let mut all: Vec<String> = all_before;
+        all.extend(new_lines);
+        all.extend(all_after);
+        self.restore(all, (top, 0));
     }
 
     // ─── Phase 4b: pub text-object resolution (hjkl#70) ─────────────────────

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -202,6 +202,10 @@ pub enum Operator {
     /// range in the buffer. Non-zero exit or spawn failure returns an error
     /// to the caller without mutating the buffer.
     Filter,
+    /// `gc{motion}` / `gcc` — toggle line comments on the row range.
+    /// Dispatched through `Editor::toggle_comment_range` rather than the
+    /// normal `run_operator_over_range` pipeline (same pattern as `Filter`).
+    Comment,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -685,6 +689,8 @@ impl VimState {
             Operator::Reflow => 'q',
             Operator::AutoIndent => '=',
             Operator::Filter => '!',
+            // `gc` prefix — doubled as `gcc`.
+            Operator::Comment => 'c',
         })
     }
 }
@@ -3298,13 +3304,28 @@ pub(crate) fn apply_op_motion_key<H: crate::types::Host>(
     }
 }
 
-/// Public(crate) entry: apply doubled-letter line op (`dd`/`yy`/`cc`/`>>`/`<<`).
+/// Public(crate) entry: apply doubled-letter line op (`dd`/`yy`/`cc`/`>>`/`<<`/`gcc`).
 /// Called by `Editor::apply_op_double` (the public controller API).
 pub(crate) fn apply_op_double<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
     op: Operator,
     total_count: usize,
 ) {
+    if op == Operator::Comment {
+        // `gcc` / `{N}gcc` — toggle comment on `total_count` lines starting at cursor.
+        let row = buf_cursor_pos(&ed.buffer).row;
+        let end_row = (row + total_count.max(1) - 1).min(ed.buffer.row_count().saturating_sub(1));
+        ed.toggle_comment_range(row, end_row);
+        ed.vim.mode = Mode::Normal;
+        if !ed.vim.replaying {
+            ed.vim.last_change = Some(LastChange::LineOp {
+                op,
+                count: total_count,
+                inserted: None,
+            });
+        }
+        return;
+    }
     execute_line_op(ed, op, total_count);
     if !ed.vim.replaying {
         ed.vim.last_change = Some(LastChange::LineOp {
@@ -3470,6 +3491,16 @@ pub(crate) fn apply_after_g<H: crate::types::Host>(
                 ed.jump_cursor(row, col);
             }
             begin_insert(ed, count.max(1), InsertReason::Enter(InsertEntry::I));
+        }
+        // `gc` — enter operator-pending for the comment-toggle operator.
+        // `gcc` (doubled 'c') is the line-wise form; `gc{motion}` is the
+        // motion form. The operator is Comment — the app layer (or the
+        // doubled-char path in handle_after_op) calls toggle_comment_range.
+        'c' => {
+            ed.vim.pending = Pending::Op {
+                op: Operator::Comment,
+                count1: count,
+            };
         }
         // `g;` / `g,` — walk the change list. `g;` toward older
         // entries, `g,` toward newer.
@@ -3725,6 +3756,16 @@ pub(crate) fn apply_op_with_motion<H: crate::types::Host>(
     let kind = motion_kind(motion);
     // Restore cursor before selecting (so Yank leaves cursor at start).
     ed.jump_cursor(start.0, start.1);
+
+    // Comment is always linewise regardless of motion kind — toggle rows.
+    if op == Operator::Comment {
+        let top = start.0.min(end.0);
+        let bot = start.0.max(end.0);
+        ed.toggle_comment_range(top, bot);
+        ed.vim.mode = Mode::Normal;
+        return;
+    }
+
     run_operator_over_range(ed, op, start, end, kind);
 }
 
@@ -3879,6 +3920,10 @@ fn run_operator_over_range<H: crate::types::Host>(
             // The app calls Editor::filter_range directly with a command string.
             // Reaching this arm means a caller invoked run_operator_over_range
             // with Operator::Filter by mistake — silently no-op.
+        }
+        Operator::Comment => {
+            // Comment is dispatched through Editor::toggle_comment_range.
+            // Reaching this arm is a caller mistake — silently no-op.
         }
     }
 }
@@ -4775,6 +4820,12 @@ fn execute_line_op<H: crate::types::Host>(
         Operator::Filter => {
             // Filter is dispatched through Editor::filter_range, not here.
         }
+        Operator::Comment => {
+            // Comment is dispatched through Editor::toggle_comment_range, not here.
+            // The doubled `gcc` path calls toggle_comment_range directly in
+            // apply_after_g, then records last_change. execute_line_op should
+            // not be reached for Comment — no-op if it is.
+        }
     }
 }
 
@@ -4870,6 +4921,8 @@ pub(crate) fn apply_visual_operator<H: crate::types::Host>(
                 }
                 // Filter is dispatched through Editor::filter_range, not here.
                 Operator::Filter => {}
+                // Comment is dispatched through the app layer (engine_actions.rs), not here.
+                Operator::Comment => {}
                 // Visual `zf` is handled inline in `handle_after_z`,
                 // never routed through this dispatcher.
                 Operator::Fold => unreachable!("Visual zf takes its own path"),
@@ -4938,6 +4991,8 @@ pub(crate) fn apply_visual_operator<H: crate::types::Host>(
                 }
                 // Filter is dispatched through Editor::filter_range, not here.
                 Operator::Filter => {}
+                // Comment is dispatched through the app layer (engine_actions.rs), not here.
+                Operator::Comment => {}
                 Operator::Fold => unreachable!("Visual zf takes its own path"),
             }
         }
@@ -5080,6 +5135,8 @@ fn apply_block_operator<H: crate::types::Host>(
         }
         // Filter is dispatched through Editor::filter_range, not here.
         Operator::Filter => {}
+        // Comment is dispatched through the app layer (engine_actions.rs), not here.
+        Operator::Comment => {}
     }
 }
 
@@ -6662,5 +6719,158 @@ mod comment_continuation_tests {
         let ed = Editor::new(buf, host, Options::default());
         let cont = continue_comment(&ed.buffer, &ed.settings, 0);
         assert!(cont.is_none());
+    }
+}
+
+#[cfg(test)]
+mod comment_toggle_tests {
+    use super::*;
+    use crate::{DefaultHost, Editor, Options};
+    use hjkl_buffer::Buffer;
+
+    fn make_rust_editor(content: &str) -> Editor<Buffer, DefaultHost> {
+        let buf = Buffer::from_str(content);
+        let host = DefaultHost::new();
+        let opts = Options {
+            filetype: "rust".to_string(),
+            ..Options::default()
+        };
+        Editor::new(buf, host, opts)
+    }
+
+    fn line(ed: &Editor<Buffer, DefaultHost>, row: usize) -> String {
+        buf_line(&ed.buffer, row).unwrap_or_default()
+    }
+
+    // ── gcc: toggle comment on current line ──────────────────────────────────
+
+    #[test]
+    fn gcc_comments_rust_line() {
+        let mut ed = make_rust_editor("let x = 1;");
+        ed.toggle_comment_range(0, 0);
+        assert_eq!(line(&ed, 0), "// let x = 1;");
+    }
+
+    #[test]
+    fn gcc_uncomments_rust_line() {
+        let mut ed = make_rust_editor("// let x = 1;");
+        ed.toggle_comment_range(0, 0);
+        assert_eq!(line(&ed, 0), "let x = 1;");
+    }
+
+    #[test]
+    fn gcc_indent_preserving() {
+        // Marker inserted after leading whitespace, not at column 0.
+        let mut ed = make_rust_editor("    let x = 1;");
+        ed.toggle_comment_range(0, 0);
+        assert_eq!(line(&ed, 0), "    // let x = 1;");
+    }
+
+    #[test]
+    fn gcc_indent_preserving_uncomment() {
+        let mut ed = make_rust_editor("    // let x = 1;");
+        ed.toggle_comment_range(0, 0);
+        assert_eq!(line(&ed, 0), "    let x = 1;");
+    }
+
+    // ── Multi-line toggle ────────────────────────────────────────────────────
+
+    #[test]
+    fn toggle_multi_line_all_uncommented() {
+        let content = "let a = 1;\nlet b = 2;\nlet c = 3;";
+        let mut ed = make_rust_editor(content);
+        ed.toggle_comment_range(0, 2);
+        assert_eq!(line(&ed, 0), "// let a = 1;");
+        assert_eq!(line(&ed, 1), "// let b = 2;");
+        assert_eq!(line(&ed, 2), "// let c = 3;");
+    }
+
+    #[test]
+    fn toggle_multi_line_all_commented() {
+        let content = "// let a = 1;\n// let b = 2;\n// let c = 3;";
+        let mut ed = make_rust_editor(content);
+        ed.toggle_comment_range(0, 2);
+        assert_eq!(line(&ed, 0), "let a = 1;");
+        assert_eq!(line(&ed, 1), "let b = 2;");
+        assert_eq!(line(&ed, 2), "let c = 3;");
+    }
+
+    // ── Mixed state → all gets commented (vim-commentary parity) ────────────
+
+    #[test]
+    fn toggle_mixed_state_comments_all() {
+        // 3 uncommented + 2 commented → all 5 get commented.
+        let content = "let a = 1;\n// let b = 2;\nlet c = 3;\n// let d = 4;\nlet e = 5;";
+        let mut ed = make_rust_editor(content);
+        ed.toggle_comment_range(0, 4);
+        for r in 0..5 {
+            assert!(
+                line(&ed, r).trim_start().starts_with("//"),
+                "row {r} not commented: {:?}",
+                line(&ed, r)
+            );
+        }
+    }
+
+    // ── Blank lines skipped ──────────────────────────────────────────────────
+
+    #[test]
+    fn blank_lines_not_commented() {
+        let content = "let a = 1;\n\nlet b = 2;";
+        let mut ed = make_rust_editor(content);
+        ed.toggle_comment_range(0, 2);
+        assert_eq!(line(&ed, 0), "// let a = 1;");
+        assert_eq!(line(&ed, 1), ""); // blank — untouched
+        assert_eq!(line(&ed, 2), "// let b = 2;");
+    }
+
+    // ── Python hash comments ─────────────────────────────────────────────────
+
+    #[test]
+    fn python_comment_toggle() {
+        let buf = Buffer::from_str("x = 1\ny = 2");
+        let host = DefaultHost::new();
+        let opts = Options {
+            filetype: "python".to_string(),
+            ..Options::default()
+        };
+        let mut ed = Editor::new(buf, host, opts);
+        ed.toggle_comment_range(0, 1);
+        assert_eq!(line(&ed, 0), "# x = 1");
+        assert_eq!(line(&ed, 1), "# y = 2");
+        // Toggle back.
+        ed.toggle_comment_range(0, 1);
+        assert_eq!(line(&ed, 0), "x = 1");
+        assert_eq!(line(&ed, 1), "y = 2");
+    }
+
+    // ── commentstring override ───────────────────────────────────────────────
+
+    #[test]
+    fn commentstring_override_via_setting() {
+        let buf = Buffer::from_str("hello world");
+        let host = DefaultHost::new();
+        let opts = Options {
+            filetype: "rust".to_string(),
+            ..Options::default()
+        };
+        let mut ed = Editor::new(buf, host, opts);
+        // Override with a custom marker.
+        ed.settings_mut().commentstring = "# %s".to_string();
+        ed.toggle_comment_range(0, 0);
+        assert_eq!(line(&ed, 0), "# hello world");
+    }
+
+    // ── Unknown language → no-op ─────────────────────────────────────────────
+
+    #[test]
+    fn unknown_lang_no_op() {
+        let buf = Buffer::from_str("hello");
+        let host = DefaultHost::new();
+        let opts = Options::default(); // filetype = ""
+        let mut ed = Editor::new(buf, host, opts);
+        ed.toggle_comment_range(0, 0);
+        // Should be unchanged — no comment string for "".
+        assert_eq!(line(&ed, 0), "hello");
     }
 }

--- a/crates/hjkl-ex/Cargo.toml
+++ b/crates/hjkl-ex/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [dependencies]
 hjkl-engine.workspace = true
 hjkl-buffer.workspace = true
+hjkl-lang.workspace = true
 regex = "1"
 
 [dev-dependencies]

--- a/crates/hjkl-ex/src/builtins.rs
+++ b/crates/hjkl-ex/src/builtins.rs
@@ -1108,6 +1108,155 @@ pub(crate) fn register_builtins<H: Host>(reg: &mut Registry<H>) {
         min_prefix: 1,
         run: |editor, args, range| vglobal_handler(editor, args, range),
     });
+
+    // ---- Phase #187 -----------------------------------------------------------
+
+    // `:comment` (min_prefix=3; toggle line comments; range-aware)
+    reg.add(ExCommand {
+        name: "comment",
+        aliases: &[],
+        arg_kind: ArgKind::None,
+        min_prefix: 3,
+        run: comment_handler::<H>,
+    });
+
+    // `:uncomment` (min_prefix=5; force-strip line comments; range-aware)
+    reg.add(ExCommand {
+        name: "uncomment",
+        aliases: &[],
+        arg_kind: ArgKind::None,
+        min_prefix: 5,
+        run: uncomment_handler::<H>,
+    });
+}
+
+// ---- comment / uncomment (#187) --------------------------------------------
+
+/// `:[range]comment` — toggle line comments on the range.
+///
+/// Toggle algorithm (vim-commentary parity):
+/// - Scan non-blank lines.  If every non-blank line is commented → uncomment.
+/// - Otherwise → comment all non-blank lines.
+///
+/// No range → current cursor line.
+fn comment_handler<H: Host>(
+    editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    _args: &str,
+    range: Option<LineRange>,
+) -> Option<ExEffect> {
+    let (top, bot) = resolve_comment_range(editor, range);
+    editor.toggle_comment_range(top, bot);
+    Some(ExEffect::Ok)
+}
+
+/// `:[range]uncomment` — force-remove comment markers (idempotent no-op when
+/// not commented).
+///
+/// Achieves "force uncomment" by temporarily overriding the all-commented
+/// check: scan each non-blank line and strip exactly one occurrence of the
+/// comment marker if present. Lines that are not commented are left unchanged.
+fn uncomment_handler<H: Host>(
+    editor: &mut hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    _args: &str,
+    range: Option<LineRange>,
+) -> Option<ExEffect> {
+    use hjkl_lang::comment::commentstring_for_lang;
+
+    let (top, bot) = resolve_comment_range(editor, range);
+    let lang = editor.settings().filetype.clone();
+
+    // Resolve comment markers (same priority as toggle_comment_range).
+    let (start, end): (String, Option<String>) = if !editor.settings().commentstring.is_empty() {
+        let cs = editor.settings().commentstring.clone();
+        if let Some(idx) = cs.find("%s") {
+            let s = cs[..idx].trim_end().to_string();
+            let e_raw = cs[idx + 2..].trim_start();
+            let e = if e_raw.is_empty() {
+                None
+            } else {
+                Some(e_raw.to_string())
+            };
+            (s, e)
+        } else {
+            (cs, None)
+        }
+    } else {
+        match commentstring_for_lang(&lang) {
+            Some((s, e)) => (s.to_string(), e.map(|v| v.to_string())),
+            None => return Some(ExEffect::Ok), // no-op
+        }
+    };
+
+    // Collect lines using the public buffer API.
+    let row_count = editor.buffer().row_count();
+    let top_c = top.min(row_count.saturating_sub(1));
+    let bot_c = bot.min(row_count.saturating_sub(1));
+
+    let lines: Vec<String> = (top_c..=bot_c)
+        .map(|r| editor.buffer().line(r).unwrap_or_default())
+        .collect();
+
+    let mut new_lines: Vec<String> = Vec::with_capacity(lines.len());
+    for line in &lines {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            new_lines.push(line.clone());
+            continue;
+        }
+        let indent_len = line.len() - trimmed.len();
+        let indent = &line[..indent_len];
+
+        if let Some(after_start) = trimmed.strip_prefix(start.as_str()) {
+            let after_space = after_start.strip_prefix(' ').unwrap_or(after_start);
+            let text = if let Some(ref end_marker) = end {
+                after_space
+                    .trim_end()
+                    .strip_suffix(end_marker.as_str())
+                    .map(|s| s.trim_end())
+                    .unwrap_or(after_space)
+            } else {
+                after_space
+            };
+            new_lines.push(format!("{indent}{text}"));
+        } else {
+            // Not commented — leave unchanged.
+            new_lines.push(line.clone());
+        }
+    }
+
+    editor.push_undo();
+    let total_rows = editor.buffer().row_count();
+    let all_before: Vec<String> = (0..top_c)
+        .map(|r| editor.buffer().line(r).unwrap_or_default())
+        .collect();
+    let all_after: Vec<String> = ((bot_c + 1)..total_rows)
+        .map(|r| editor.buffer().line(r).unwrap_or_default())
+        .collect();
+    let mut all: Vec<String> = all_before;
+    all.extend(new_lines);
+    all.extend(all_after);
+    editor.restore(all, (top_c, 0));
+
+    Some(ExEffect::Ok)
+}
+
+/// Resolve a `LineRange` to `(top, bot)` 0-based row indices.
+/// No range → current cursor line.
+fn resolve_comment_range<H: Host>(
+    editor: &hjkl_engine::Editor<hjkl_buffer::Buffer, H>,
+    range: Option<LineRange>,
+) -> (usize, usize) {
+    match range {
+        Some(lr) => {
+            let top = lr.start_one_based().saturating_sub(1);
+            let bot = lr.end_one_based().saturating_sub(1);
+            (top, bot)
+        }
+        None => {
+            let row = editor.cursor().0;
+            (row, row)
+        }
+    }
 }
 
 // ---- unit tests ------------------------------------------------------------
@@ -1996,5 +2145,94 @@ mod tests {
             "expected Substituted(1) (first only), got {result:?}"
         );
         assert_eq!(ed.buffer().line(1).unwrap_or_default(), "y x x");
+    }
+
+    // ── comment_handler / uncomment_handler (#187) ────────────────────────────
+
+    fn make_rust_editor() -> Editor<hjkl_buffer::Buffer, DefaultHost> {
+        let buf = hjkl_buffer::Buffer::from_str("let a = 1;\nlet b = 2;\nlet c = 3;");
+        let host = DefaultHost::new();
+        let opts = Options {
+            filetype: "rust".to_string(),
+            ..Options::default()
+        };
+        Editor::new(buf, host, opts)
+    }
+
+    #[test]
+    fn comment_handler_gcc_toggles_current_line() {
+        let mut ed = make_rust_editor();
+        // No range → cursor line (row 0).
+        let result = comment_handler(&mut ed, "", None);
+        assert_eq!(result, Some(ExEffect::Ok));
+        assert_eq!(ed.buffer().line(0).unwrap_or_default(), "// let a = 1;");
+        assert_eq!(ed.buffer().line(1).unwrap_or_default(), "let b = 2;");
+    }
+
+    #[test]
+    fn comment_handler_range_toggles_range() {
+        let mut ed = make_rust_editor();
+        let range = LineRange::new(1, 3); // 1-based: lines 1–3
+        let result = comment_handler(&mut ed, "", Some(range));
+        assert_eq!(result, Some(ExEffect::Ok));
+        assert_eq!(ed.buffer().line(0).unwrap_or_default(), "// let a = 1;");
+        assert_eq!(ed.buffer().line(1).unwrap_or_default(), "// let b = 2;");
+        assert_eq!(ed.buffer().line(2).unwrap_or_default(), "// let c = 3;");
+    }
+
+    #[test]
+    fn comment_handler_whole_buffer_toggle() {
+        // :%comment equivalent — toggle all lines.
+        let mut ed = make_rust_editor();
+        let range = LineRange::new(1, 3);
+        comment_handler(&mut ed, "", Some(range));
+        // All should be commented now.
+        assert!(ed.buffer().line(0).unwrap_or_default().starts_with("//"));
+        assert!(ed.buffer().line(1).unwrap_or_default().starts_with("//"));
+        // Toggle again → all uncommented.
+        comment_handler(&mut ed, "", Some(range));
+        assert!(!ed.buffer().line(0).unwrap_or_default().starts_with("//"));
+        assert!(!ed.buffer().line(1).unwrap_or_default().starts_with("//"));
+    }
+
+    #[test]
+    fn uncomment_handler_strips_comments_idempotent() {
+        let buf = hjkl_buffer::Buffer::from_str("// let a = 1;\nlet b = 2;");
+        let host = DefaultHost::new();
+        let opts = Options {
+            filetype: "rust".to_string(),
+            ..Options::default()
+        };
+        let mut ed = Editor::new(buf, host, opts);
+        let range = LineRange::new(1, 2);
+        let result = uncomment_handler(&mut ed, "", Some(range));
+        assert_eq!(result, Some(ExEffect::Ok));
+        // Line 0: comment stripped.
+        assert_eq!(ed.buffer().line(0).unwrap_or_default(), "let a = 1;");
+        // Line 1: already uncommented — unchanged.
+        assert_eq!(ed.buffer().line(1).unwrap_or_default(), "let b = 2;");
+    }
+
+    #[test]
+    fn mixed_state_range_gets_fully_commented() {
+        // 3 uncommented + 2 commented → all 5 get commented (vim-commentary parity).
+        let buf = hjkl_buffer::Buffer::from_str(
+            "let a = 1;\n// let b = 2;\nlet c = 3;\n// let d = 4;\nlet e = 5;",
+        );
+        let host = DefaultHost::new();
+        let opts = Options {
+            filetype: "rust".to_string(),
+            ..Options::default()
+        };
+        let mut ed = Editor::new(buf, host, opts);
+        let range = LineRange::new(1, 5);
+        comment_handler(&mut ed, "", Some(range));
+        for row in 0..5 {
+            let l = ed.buffer().line(row).unwrap_or_default();
+            assert!(
+                l.trim_start().starts_with("//"),
+                "row {row} should be commented; got {l:?}"
+            );
+        }
     }
 }

--- a/crates/hjkl-ex/src/setopt.rs
+++ b/crates/hjkl-ex/src/setopt.rs
@@ -40,6 +40,8 @@ pub fn all_setting_names() -> Vec<String> {
         "fo".into(),
         "filetype".into(),
         "ft".into(),
+        "commentstring".into(),
+        "cms".into(),
         // completion-only (handled by host in ex_dispatch.rs)
         "background".into(),
         "bg".into(),
@@ -95,7 +97,7 @@ pub(crate) fn apply_set<H: Host>(
             hjkl_engine::types::SignColumnMode::Auto => "auto",
         };
         return ExEffect::Info(format!(
-            "shiftwidth={}  tabstop={}  softtabstop={}  textwidth={}  undolevels={}  timeoutlen={}  iskeyword=\"{}\"  expandtab={}  ignorecase={}  smartcase={}  wrapscan={}  autoindent={}  smartindent={}  undobreak={}  readonly={}  wrap={}  number={}  relativenumber={}  numberwidth={}  cursorline={}  cursorcolumn={}  signcolumn={}  foldcolumn={}  colorcolumn=\"{}\"  formatoptions=\"{}\"  filetype=\"{}\"",
+            "shiftwidth={}  tabstop={}  softtabstop={}  textwidth={}  undolevels={}  timeoutlen={}  iskeyword=\"{}\"  expandtab={}  ignorecase={}  smartcase={}  wrapscan={}  autoindent={}  smartindent={}  undobreak={}  readonly={}  wrap={}  number={}  relativenumber={}  numberwidth={}  cursorline={}  cursorcolumn={}  signcolumn={}  foldcolumn={}  colorcolumn=\"{}\"  formatoptions=\"{}\"  filetype=\"{}\"  commentstring=\"{}\"",
             s.shiftwidth,
             s.tabstop,
             s.softtabstop,
@@ -122,6 +124,7 @@ pub(crate) fn apply_set<H: Host>(
             s.colorcolumn,
             s.formatoptions,
             s.filetype,
+            s.commentstring,
         ));
     }
     for token in trimmed.split_whitespace() {
@@ -192,6 +195,10 @@ fn apply_set_token<H: Host>(
         }
         if matches!(name, "filetype" | "ft") {
             editor.settings_mut().filetype = value.to_string();
+            return Ok(());
+        }
+        if matches!(name, "commentstring" | "cms") {
+            editor.settings_mut().commentstring = value.to_string();
             return Ok(());
         }
         let parsed: usize = value

--- a/crates/hjkl-lang/src/comment.rs
+++ b/crates/hjkl-lang/src/comment.rs
@@ -74,6 +74,54 @@ pub fn detect_comment_prefix<'a>(lang: &str, line: &'a str) -> Option<(&'a str, 
     None
 }
 
+/// Return the comment-string markers for `lang` as `(start, end)`.
+///
+/// For line-comment languages `end` is `None` — the toggle inserts `start`
+/// (plus one space) before the non-blank text and removes it on uncomment.
+///
+/// For block-comment languages (HTML, CSS, …) `end` is `Some(end_marker)` —
+/// each line is wrapped individually as `start text end`.
+///
+/// Returns `None` for unrecognised languages. The caller should fall back to
+/// an empty prefix (no-op toggle) when `None` is returned.
+///
+/// The markers here deliberately do NOT include trailing/leading spaces —
+/// the toggle algorithm adds/removes exactly one space separator.
+///
+/// | Language group                           | start  | end     |
+/// |------------------------------------------|--------|---------|
+/// | Rust, C, C++, JS, TS, Go, Java, Swift    | `//`   | —       |
+/// | Python, Shell, TOML, YAML, Make, Ruby, Perl | `#` | —       |
+/// | Lua, SQL, Haskell, Ada                   | `--`   | —       |
+/// | Vim / Vimscript                          | `"`    | —       |
+/// | LaTeX, MATLAB                            | `%`    | —       |
+/// | HTML, XML, SVG                           | ``  | `` |
+/// | CSS, SCSS                                | `/*`   | `*/`    |
+pub fn commentstring_for_lang(lang: &str) -> Option<(&'static str, Option<&'static str>)> {
+    match lang {
+        // Rust — plain `//` for gc toggle (not the doc-comment variants).
+        "rust" => Some(("//", None)),
+        // C / C++ / JavaScript / TypeScript / Go / Java / Swift
+        "c" | "cpp" | "javascript" | "js" | "typescript" | "ts" | "go" | "java" | "swift" => {
+            Some(("//", None))
+        }
+        // Python / Shell variants / TOML / YAML / Makefile / Ruby / Perl
+        "python" | "sh" | "bash" | "zsh" | "fish" | "toml" | "yaml" | "make" | "makefile"
+        | "ruby" | "perl" => Some(("#", None)),
+        // Lua / SQL / Haskell / Ada
+        "lua" | "sql" | "haskell" | "ada" => Some(("--", None)),
+        // Vim / Vimscript
+        "vim" | "viml" => Some(("\"", None)),
+        // LaTeX / MATLAB
+        "latex" | "tex" | "matlab" => Some(("%", None)),
+        // HTML / XML / SVG — block style, wrap each line individually.
+        "html" | "xml" | "svg" => Some(("<!--", Some("-->"))),
+        // CSS / SCSS — block style.
+        "css" | "scss" => Some(("/*", Some("*/"))),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,5 +187,47 @@ mod tests {
         // A line that is exactly `//` with nothing after it should still match.
         let result = detect_comment_prefix("rust", "//");
         assert!(result.is_some());
+    }
+
+    // ── commentstring_for_lang ───────────────────────────────────────────────
+
+    #[test]
+    fn commentstring_rust_is_slash_slash() {
+        let (start, end) = commentstring_for_lang("rust").unwrap();
+        assert_eq!(start, "//");
+        assert!(end.is_none());
+    }
+
+    #[test]
+    fn commentstring_python_is_hash() {
+        let (start, end) = commentstring_for_lang("python").unwrap();
+        assert_eq!(start, "#");
+        assert!(end.is_none());
+    }
+
+    #[test]
+    fn commentstring_lua_is_dash_dash() {
+        let (start, end) = commentstring_for_lang("lua").unwrap();
+        assert_eq!(start, "--");
+        assert!(end.is_none());
+    }
+
+    #[test]
+    fn commentstring_html_is_block() {
+        let (start, end) = commentstring_for_lang("html").unwrap();
+        assert_eq!(start, "<!--");
+        assert_eq!(end, Some("-->"));
+    }
+
+    #[test]
+    fn commentstring_css_is_block() {
+        let (start, end) = commentstring_for_lang("css").unwrap();
+        assert_eq!(start, "/*");
+        assert_eq!(end, Some("*/"));
+    }
+
+    #[test]
+    fn commentstring_unknown_lang_returns_none() {
+        assert!(commentstring_for_lang("brainfuck").is_none());
     }
 }

--- a/crates/hjkl-vim/src/descriptors.rs
+++ b/crates/hjkl-vim/src/descriptors.rs
@@ -80,7 +80,7 @@ pub fn children_for(mode: Mode, prefix: &[KeyEvent]) -> Vec<VimDescriptor> {
 /// Expected count of root Normal-mode descriptors.
 pub const COUNT_NORMAL_ROOT: usize = 84;
 /// Expected count of g-prefix descriptors.
-pub const COUNT_G_PREFIX: usize = 19;
+pub const COUNT_G_PREFIX: usize = 20;
 /// Expected count of z-prefix descriptors.
 pub const COUNT_Z_PREFIX: usize = 11;
 /// Expected count of operator-pending root descriptors (d/c/y prefix children).
@@ -121,6 +121,11 @@ fn children_visual(prefix: &[KeyEvent]) -> Vec<VimDescriptor> {
     }
     if prefix.len() == 1 && prefix[0] == KeyEvent::char('z') {
         return z_prefix();
+    }
+    if prefix.len() == 1 && prefix[0] == KeyEvent::char('g') {
+        // In visual mode only `gc` is relevant; return the same g-prefix table
+        // so which-key shows it alongside gv / gj / gk that visual mode supports.
+        return g_prefix();
     }
     vec![]
 }
@@ -280,6 +285,8 @@ fn visual_root() -> Vec<VimDescriptor> {
         VimDescriptor::prefix('z'),
         // Mark goto.
         VimDescriptor::char('`', "goto mark (charwise)"),
+        // Comment toggle.
+        VimDescriptor::char('g', "g-prefix (gc = toggle comment)"),
     ]
 }
 
@@ -305,6 +312,7 @@ fn g_prefix() -> Vec<VimDescriptor> {
         VimDescriptor::char(',', "goto newer change"),
         VimDescriptor::char('*', "search word (partial) forward"),
         VimDescriptor::char('#', "search word (partial) backward"),
+        VimDescriptor::char('c', "toggle comment operator"),
     ]
 }
 

--- a/crates/hjkl-vim/src/normal.rs
+++ b/crates/hjkl-vim/src/normal.rs
@@ -656,6 +656,8 @@ fn handle_after_op<H: Host>(
         Operator::AutoIndent => Some('='),
         // `!!` filters the current line — vim's doubled form.
         Operator::Filter => Some('!'),
+        // `gcc` toggles comment on the current line — doubled 'c' after `gc`.
+        Operator::Comment => Some('c'),
     };
     if let Key::Char(c) = input.key
         && !input.ctrl

--- a/crates/hjkl-vim/src/operator.rs
+++ b/crates/hjkl-vim/src/operator.rs
@@ -31,13 +31,17 @@ pub enum OperatorKind {
     /// range the grammar transitions to `PendingFilter` and waits for the
     /// app to supply a command string before emitting `EngineCmd::ApplyFilter`.
     Filter,
+    /// `gc` — toggle line comments on the range. `gcc` = current line (doubled-
+    /// char convention, like `dd`). `gc{motion}` = motion variant. All three
+    /// visual modes resolve to a row range and call `toggle_comment_range`.
+    Comment,
 }
 
 impl OperatorKind {
     /// The doubled-letter char for this operator.
     ///
     /// Used by the `AfterOp` reducer arm to detect the line-op doubled form:
-    /// `dd`, `yy`, `cc`, `>>`, `<<`, `gUU`, `guu`, `g~~`, `gqq`.
+    /// `dd`, `yy`, `cc`, `>>`, `<<`, `gUU`, `guu`, `g~~`, `gqq`, `gcc`.
     pub(crate) fn double_char(self) -> char {
         match self {
             OperatorKind::Delete => 'd',
@@ -51,6 +55,8 @@ impl OperatorKind {
             OperatorKind::Reflow => 'q',
             OperatorKind::AutoIndent => '=',
             OperatorKind::Filter => '!',
+            // `gcc` — doubled 'c' after `gc` enters the comment operator.
+            OperatorKind::Comment => 'c',
         }
     }
 }


### PR DESCRIPTION
Closes #187

## Summary

- **hjkl-lang**: Added `commentstring_for_lang(lang)` returning `(start, Option<end>)` — extends existing `comment_prefixes` table without duplication. Covers Rust/C/C++/JS/TS/Go (//), Python/Shell/TOML/YAML (#), Lua/SQL/Haskell (--), Vim ("), LaTeX (%), HTML/XML (<!-- -->), CSS (/* */)
- **hjkl-engine**: Added `Operator::Comment` variant; `Settings::commentstring` field; `Editor::toggle_comment_range(top, bot)` helper — indent-preserving, all-commented detection, single undo step, block-style per-line wrapping for HTML/CSS
- **hjkl-vim**: Added `OperatorKind::Comment` with doubled char 'c'; wired `gc` in `apply_after_g` (enters op-pending); `gcc` double dispatches to `toggle_comment_range`; `gc{motion}` applies over motion's row span; updated g-prefix descriptor count (19→20)
- **hjkl-ex**: Added `:comment` (min_prefix=3, toggle) and `:uncomment` (min_prefix=5, force-strip) with `[range]` support; added `commentstring`/`cms` to `:set` option table
- **apps/hjkl**: Wired `OperatorKind::Comment` in all three visual mode arms (charwise, linewise, block) in `engine_actions.rs` + `event_loop.rs` operator map

## Scope decisions

- HTML/CSS block markers: per-line wrapping (each line individually wrapped as `<!-- foo -->`), not multi-line block — per spec
- `gc` in visual modes dispatched directly via `toggle_comment_range`, not through engine FSM visual operator path (same pattern as `Filter`)

## Test plan

- [x] `gcc_comments_rust_line`, `gcc_uncomments_rust_line`, `gcc_indent_preserving` — normal gcc behavior
- [x] `toggle_mixed_state_comments_all` — mixed-state range gets fully commented
- [x] `blank_lines_not_commented` — blanks skipped
- [x] `python_comment_toggle` — hash language
- [x] `commentstring_override_via_setting` — `:set commentstring=#` override works
- [x] `comment_handler_*` / `uncomment_handler_strips_comments_idempotent` / `mixed_state_range_gets_fully_commented` — ex command coverage
- [x] All 669 crate tests pass; pre-existing clipboard failures unchanged