### PR TITLE
feat(insert): autopair brackets/quotes + auto-close HTML/XML tags + skip-over

### DIFF
--- a/apps/hjkl/tests/autopair.rs
+++ b/apps/hjkl/tests/autopair.rs
@@ -1,0 +1,459 @@
+//! Integration tests for autopair brackets/quotes + auto-close HTML/XML tags
+//! + skip-over on duplicate (issue #181).
+//!
+//! Tests drive the engine directly (no binary spawn) to verify:
+//! - Basic pair insertion `(` → `(|)`
+//! - Skip-over when typing the close char over an auto-inserted close
+//! - Apostrophe prose fallthrough: `don'` stays `don'`
+//! - Cursor motion clears the pending-closes stack
+//! - Tag autoclose for HTML filetypes
+//! - Void element suppression
+//! - Self-closing tag suppression
+//! - `:set noautopair` disables all pairing
+//! - `:set noautoclose-tag` disables tag autoclose
+//! - Open-pair-newline: Enter between `{|}` expands to indented block
+
+use hjkl_buffer::Buffer;
+use hjkl_engine::{DefaultHost, Editor, Options};
+use hjkl_vim::{dispatch_input, insert::step_insert};
+
+// ---------------------------------------------------------------------------
+// Test harness helpers
+// ---------------------------------------------------------------------------
+
+fn editor(lang: &str, content: &str) -> Editor<Buffer, DefaultHost> {
+    let buf = Buffer::from_str(content);
+    let host = DefaultHost::new();
+    let opts = Options {
+        filetype: lang.to_string(),
+        formatoptions: "ro".to_string(),
+        ..Options::default()
+    };
+    Editor::new(buf, host, opts)
+}
+
+/// Feed keystrokes through the normal/insert dispatcher.
+fn feed(ed: &mut Editor<Buffer, DefaultHost>, keys: &str) {
+    use hjkl_engine::{Input, Key};
+    for ch in keys.chars() {
+        let input = match ch {
+            '\n' => Input {
+                key: Key::Enter,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            '\x08' => Input {
+                key: Key::Backspace,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            '\x1b' => Input {
+                key: Key::Esc,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            _ => Input {
+                key: Key::Char(ch),
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+        };
+        dispatch_input(ed, input);
+    }
+}
+
+/// Feed keystrokes directly to the insert-mode FSM.
+fn feed_insert(ed: &mut Editor<Buffer, DefaultHost>, keys: &str) {
+    use hjkl_engine::{Input, Key};
+    for ch in keys.chars() {
+        let input = match ch {
+            '\n' => Input {
+                key: Key::Enter,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            '\x08' => Input {
+                key: Key::Backspace,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            '\x1b' => Input {
+                key: Key::Esc,
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+            _ => Input {
+                key: Key::Char(ch),
+                ctrl: false,
+                alt: false,
+                shift: false,
+            },
+        };
+        step_insert(ed, input);
+    }
+}
+
+/// Feed an arrow key to the insert-mode FSM.
+fn feed_arrow_left(ed: &mut Editor<Buffer, DefaultHost>) {
+    use hjkl_engine::{Input, Key};
+    step_insert(
+        ed,
+        Input {
+            key: Key::Left,
+            ctrl: false,
+            alt: false,
+            shift: false,
+        },
+    );
+}
+
+fn cursor(ed: &Editor<Buffer, DefaultHost>) -> (usize, usize) {
+    ed.cursor()
+}
+
+// ---------------------------------------------------------------------------
+// Basic pair insertion
+// ---------------------------------------------------------------------------
+
+/// Helper: content without the trailing newline that `ed.content()` always adds.
+fn buf_lines(ed: &Editor<Buffer, DefaultHost>) -> Vec<String> {
+    ed.buffer().lines().to_vec()
+}
+
+/// Typing `(` in insert mode inserts `()` and leaves cursor between them.
+#[test]
+fn basic_pair_paren() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i"); // enter insert mode
+    feed_insert(&mut ed, "(");
+    let lines = buf_lines(&ed);
+    assert_eq!(lines, vec!["()"], "expected '()' got {lines:?}");
+    let (row, col) = cursor(&ed);
+    assert_eq!(
+        (row, col),
+        (0, 1),
+        "cursor should be between ( and ), got ({row},{col})"
+    );
+}
+
+/// Typing `[` → `[|]`.
+#[test]
+fn basic_pair_bracket() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "[");
+    assert_eq!(buf_lines(&ed), vec!["[]"]);
+    assert_eq!(cursor(&ed), (0, 1));
+}
+
+/// Typing `{` → `{|}`.
+#[test]
+fn basic_pair_brace() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "{");
+    assert_eq!(buf_lines(&ed), vec!["{}"]);
+    assert_eq!(cursor(&ed), (0, 1));
+}
+
+/// Typing `"` → `"|"`.
+#[test]
+fn basic_pair_double_quote() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "\"");
+    assert_eq!(buf_lines(&ed), vec!["\"\""]);
+    assert_eq!(cursor(&ed), (0, 1));
+}
+
+/// Typing backtick → `` `|` ``.
+#[test]
+fn basic_pair_backtick() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "`");
+    assert_eq!(buf_lines(&ed), vec!["``"]);
+    assert_eq!(cursor(&ed), (0, 1));
+}
+
+// ---------------------------------------------------------------------------
+// Skip-over
+// ---------------------------------------------------------------------------
+
+/// After `(` auto-inserts `)`, typing `)` skips over it.
+#[test]
+fn skip_over_paren() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "("); // → "(|)"
+    let (_, col_after_open) = cursor(&ed);
+    assert_eq!(col_after_open, 1);
+    feed_insert(&mut ed, ")"); // skip-over → "()|"
+    let (row, col) = cursor(&ed);
+    assert_eq!(
+        (row, col),
+        (0, 2),
+        "skip-over should advance past ) to col 2, got ({row},{col})"
+    );
+    assert_eq!(
+        buf_lines(&ed),
+        vec!["()"],
+        "no duplicate ) should be inserted"
+    );
+}
+
+/// After `"` auto-inserts `"`, typing `"` skips over the auto-inserted close.
+#[test]
+fn skip_over_double_quote() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "\""); // → "|""
+    feed_insert(&mut ed, "hello"); // type content
+    // cursor is now at col 6, auto-close `"` is at col 6
+    feed_insert(&mut ed, "\""); // skip-over
+    let lines = buf_lines(&ed);
+    assert_eq!(lines, vec!["\"hello\""], "no duplicate quote: {lines:?}");
+    assert_eq!(cursor(&ed).1, 7, "cursor should be past closing quote");
+}
+
+// ---------------------------------------------------------------------------
+// Apostrophe prose fallthrough
+// ---------------------------------------------------------------------------
+
+/// `don` followed by `'` should NOT auto-pair (prev char is alphabetic).
+#[test]
+fn apostrophe_no_pair_after_letter() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "don");
+    feed_insert(&mut ed, "'");
+    let lines = buf_lines(&ed);
+    // Should be ["don'"] not ["don''"]
+    assert_eq!(
+        lines,
+        vec!["don'"],
+        "apostrophe after letter must not auto-pair: {lines:?}"
+    );
+}
+
+/// `'` at start of buffer (no prev char) SHOULD auto-pair.
+#[test]
+fn apostrophe_pairs_at_start() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "'");
+    assert_eq!(
+        buf_lines(&ed),
+        vec!["''"],
+        "apostrophe at start should auto-pair"
+    );
+    assert_eq!(cursor(&ed).1, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Cursor motion clears pending-closes stack
+// ---------------------------------------------------------------------------
+
+/// Type `(` (auto-inserts `)`), then press Left arrow, then type `)`.
+/// The `)` should be inserted literally (no skip-over) because the
+/// arrow key cleared the pending-closes stack.
+#[test]
+fn arrow_clears_pending_closes() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "("); // → "(|)"
+    feed_arrow_left(&mut ed); // cursor moves to col 0, stack cleared
+    feed_insert(&mut ed, ")"); // literal insert, not skip-over
+    let lines = buf_lines(&ed);
+    // Should be [")()" ] — the `)` was inserted at col 0, then `()` follows
+    let text = lines.join("");
+    assert!(
+        text.contains(")("),
+        "literal ) should be inserted, not skipped over; got {text:?}"
+    );
+}
+
+/// Mode change (Esc → Normal) clears the stack. Re-entering insert with `a`
+/// and typing `}` inserts it literally.
+#[test]
+fn mode_change_clears_pending_closes() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "{"); // → "{|}"
+    // Escape to normal mode (clears stack)
+    feed(&mut ed, "\x1b");
+    // `a` to append (enters insert after cursor)
+    feed(&mut ed, "a");
+    feed_insert(&mut ed, "}"); // literal `}`, not skip-over
+    let lines = buf_lines(&ed);
+    let text = lines.join("");
+    // We expect "{}}" — the original `{}` plus a literal `}`
+    assert!(
+        text.contains("}}"),
+        "after mode change, }} should be literally inserted; got {text:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tag autoclose
+// ---------------------------------------------------------------------------
+
+/// `<div>` in html filetype → `<div>|</div>`.
+#[test]
+fn tag_autoclose_div_html() {
+    let mut ed = editor("html", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "<div>");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["<div></div>"],
+        "expected tag autoclose: {lines:?}"
+    );
+    // Cursor should be between `>` and `</div>`, i.e. at col 5
+    assert_eq!(cursor(&ed).1, 5, "cursor should be between tags");
+}
+
+/// `<span>` in html → autoclose.
+#[test]
+fn tag_autoclose_span_html() {
+    let mut ed = editor("html", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "<span>");
+    let lines = buf_lines(&ed);
+    assert_eq!(lines, vec!["<span></span>"], "{lines:?}");
+}
+
+/// Void element `<br>` must NOT get a close tag.
+#[test]
+fn void_element_no_close() {
+    let mut ed = editor("html", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "<br>");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["<br>"],
+        "void element must not be auto-closed: {lines:?}"
+    );
+}
+
+/// Void element `<img>` must NOT get a close tag.
+#[test]
+fn void_element_img_no_close() {
+    let mut ed = editor("html", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "<img>");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["<img>"],
+        "void element img must not be auto-closed: {lines:?}"
+    );
+}
+
+/// Self-closing `<Foo />` must NOT get a close tag.
+#[test]
+fn self_closing_no_close() {
+    let mut ed = editor("jsx", "");
+    feed(&mut ed, "i");
+    // Type `<Foo />` — the `/` before `>` makes it self-closing
+    feed_insert(&mut ed, "<Foo />");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["<Foo />"],
+        "self-closing must not be auto-closed: {lines:?}"
+    );
+}
+
+/// Non-HTML filetype: `<` should not auto-pair as `<>`.
+#[test]
+fn lt_no_pair_in_rust() {
+    let mut ed = editor("rust", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "<");
+    let lines = buf_lines(&ed);
+    assert_eq!(lines, vec!["<"], "< must not pair in rust: {lines:?}");
+}
+
+// ---------------------------------------------------------------------------
+// :set noautopair
+// ---------------------------------------------------------------------------
+
+/// `:set noautopair` disables bracket pairing.
+#[test]
+fn set_noautopair_disables() {
+    let mut ed = editor("", "");
+    let reg = hjkl_ex::default_registry::<DefaultHost>();
+    hjkl_ex::try_dispatch(&reg, &mut ed, "set noautopair");
+    assert!(
+        !ed.settings().autopair,
+        "autopair should be off after :set noautopair"
+    );
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "(");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["("],
+        "with noautopair, only ( should be inserted: {lines:?}"
+    );
+}
+
+/// `:set noautoclose-tag` disables tag autoclose in HTML.
+/// With autoclose-tag off but autopair still on, `<` pairs as `<>` but `>`
+/// skip-over fires without tag autoclose.
+#[test]
+fn set_noautoclose_tag_disables() {
+    let mut ed = editor("html", "");
+    let reg = hjkl_ex::default_registry::<DefaultHost>();
+    hjkl_ex::try_dispatch(&reg, &mut ed, "set noautoclose-tag");
+    assert!(!ed.settings().autoclose_tag, "autoclose_tag should be off");
+    // Also disable autopair so `<` doesn't pair with `>` in this test.
+    ed.settings_mut().autopair = false;
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "<div>");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["<div>"],
+        "with noautoclose-tag, no </div> inserted: {lines:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Open-pair-newline
+// ---------------------------------------------------------------------------
+
+/// Enter between `{` and `}` (auto-paired) → expands to indented block.
+#[test]
+fn open_pair_newline_brace() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "{"); // → "{|}"
+    // Cursor is at col 1, between { and }
+    feed_insert(&mut ed, "\n"); // open-pair-newline
+    let lines = buf_lines(&ed);
+    // Expected: ["{", "    ", "}"] (3 lines with default 4-space indent)
+    assert_eq!(
+        lines.len(),
+        3,
+        "should have 3 lines after open-pair-newline: {lines:?}"
+    );
+    assert_eq!(lines[0], "{", "first line should be {{: {lines:?}");
+    assert_eq!(lines[2], "}", "third line should be }}: {lines:?}");
+    // Cursor should be on the inner (indented) line
+    let (row, _) = cursor(&ed);
+    assert_eq!(
+        row, 1,
+        "cursor should be on the middle (indented) line, got row {row}"
+    );
+}

--- a/crates/hjkl-engine/src/editor.rs
+++ b/crates/hjkl-engine/src/editor.rs
@@ -744,6 +744,18 @@ pub struct Settings {
     /// prefix/suffix portion (before/after `%s`).  An empty string means "use
     /// the filetype default".  Default `""`.
     pub commentstring: String,
+    /// When `true`, typing an opening bracket or quote automatically inserts
+    /// the matching close character and parks the cursor between them.
+    /// Matches vim's `set autopairs` (Neovim) / nvim-autopairs behaviour.
+    /// Default `true`.
+    pub autopair: bool,
+    /// When `true`, typing `>` to close an HTML/XML opening tag automatically
+    /// inserts `</tagname>` after the cursor. Only fires for filetypes in the
+    /// HTML/XML family (`html`, `xml`, `svg`, `jsx`, `tsx`, `vue`, `svelte`).
+    /// Matches common editor "autoclose tag" behaviour. Default: `true` for
+    /// those filetypes (the caller gates on filetype), `true` stored here so
+    /// `:set noautoclose-tag` can disable it globally.
+    pub autoclose_tag: bool,
 }
 
 impl Default for Settings {
@@ -776,6 +788,8 @@ impl Default for Settings {
             formatoptions: "ro".to_string(),
             filetype: String::new(),
             commentstring: String::new(),
+            autopair: true,
+            autoclose_tag: true,
         }
     }
 }
@@ -820,6 +834,8 @@ fn settings_from_options(o: &crate::types::Options) -> Settings {
         formatoptions: o.formatoptions.clone(),
         filetype: o.filetype.clone(),
         commentstring: String::new(),
+        autopair: true,
+        autoclose_tag: true,
     }
 }
 

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -516,6 +516,14 @@ pub struct VimState {
     pub(crate) current_mode: crate::VimMode,
     /// Most recent successful :s invocation. Stored so :& / :&& can repeat it.
     pub last_substitute: Option<crate::substitute::SubstituteCmd>,
+    /// Stack of auto-inserted closing characters awaiting skip-over.
+    ///
+    /// Each entry `(row, col, ch)` records where autopair placed a close
+    /// character. When the next typed char matches `ch` AND the cursor is
+    /// immediately before that position, the engine advances past it
+    /// ("skip-over") instead of inserting. The stack is cleared on any
+    /// cursor motion, mode change, or out-of-pair edit.
+    pub pending_closes: Vec<(usize, usize, char)>,
 }
 
 pub(crate) const SEARCH_HISTORY_MAX: usize = 100;
@@ -1210,9 +1218,124 @@ pub(crate) fn break_undo_group_in_insert<H: crate::types::Host>(
 //     (currently a no-op but kept for migration hygiene).
 //   - Returns `true` when the buffer was mutated, `false` otherwise.
 
+/// Return the filetype-gated autopair close character for `open`, or `None`
+/// when no pairing applies.
+///
+/// Rules:
+/// - `(` → `)`, `[` → `]`, `{` → `}`, `"` → `"`, `` ` `` → `` ` `` always.
+/// - `<` → `>` only for HTML/XML family filetypes.
+/// - `'` → `'` unless the character immediately before the cursor is
+///   `[A-Za-z]` (prose apostrophe guard — "don't" stays "don't").
+fn autopair_close_for(ch: char, filetype: &str, prev_char: Option<char>) -> Option<char> {
+    match ch {
+        '(' => Some(')'),
+        '[' => Some(']'),
+        '{' => Some('}'),
+        '"' => Some('"'),
+        '`' => Some('`'),
+        '<' => {
+            if is_html_filetype(filetype) {
+                Some('>')
+            } else {
+                None
+            }
+        }
+        '\'' => {
+            // Prose guard: skip pairing when the previous char is a letter
+            // (covers "don't", "it's", etc.).
+            if prev_char.map(|c| c.is_ascii_alphabetic()).unwrap_or(false) {
+                None
+            } else {
+                Some('\'')
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Filetypes that get HTML/XML-family treatment (`<` pairing + tag autoclose).
+fn is_html_filetype(ft: &str) -> bool {
+    matches!(
+        ft,
+        "html" | "xml" | "svg" | "jsx" | "tsx" | "vue" | "svelte"
+    )
+}
+
+/// Void HTML elements that must never get an auto-close tag.
+fn is_void_element(tag: &str) -> bool {
+    matches!(
+        tag.to_ascii_lowercase().as_str(),
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "source"
+            | "track"
+            | "wbr"
+    )
+}
+
+/// Scan backward from `col` (exclusive) in `line` for a `<tagname…` opener.
+///
+/// Returns `Some(tag_name)` when:
+/// - An opening `<` is found
+/// - The tag name matches `[A-Za-z][A-Za-z0-9-]*`
+/// - The tag is not self-closing (does not end with `/` before `>`)
+/// - The tag is not a void element
+///
+/// Returns `None` otherwise (no opener, self-closing, void, or malformed).
+fn scan_tag_opener(line: &str, col: usize) -> Option<String> {
+    // col is where `>` was just inserted (the char is already in the line).
+    // We look at the slice BEFORE the `>`.
+    let before = if col > 0 { &line[..col] } else { return None };
+
+    // Walk backward to find the matching `<`.
+    let lt_pos = before.rfind('<')?;
+    let inner = &before[lt_pos + 1..]; // e.g. "div class=\"foo\""
+
+    // A `!` opener is a comment/doctype — skip.
+    if inner.starts_with('!') {
+        return None;
+    }
+    // Self-closing if the last non-space char before `>` was `/`.
+    if inner.trim_end().ends_with('/') {
+        return None;
+    }
+
+    // Extract tag name: first token of `inner`.
+    let tag: String = inner
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '-')
+        .collect();
+    if tag.is_empty() {
+        return None;
+    }
+    // First char must be a letter.
+    if !tag
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_alphabetic())
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    if is_void_element(&tag) {
+        return None;
+    }
+    Some(tag)
+}
+
 /// Insert a single character at the cursor. Handles replace-mode overstrike
 /// (when `InsertSession::reason` is `Replace`) and smart-indent dedent of
-/// closing brackets (}/)]/). Returns `true`.
+/// closing brackets (}/)]/). Also handles autopair insertion and skip-over.
+/// Returns `true`.
 pub(crate) fn insert_char_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
     ch: char,
@@ -1225,7 +1348,56 @@ pub(crate) fn insert_char_bridge<H: crate::types::Host>(
         ed.vim.insert_session.as_ref().map(|s| &s.reason),
         Some(InsertReason::Replace)
     );
+
+    // ── Skip-over: if the typed char matches the top of the pending-closes
+    // stack AND the char currently under the cursor IS that close char,
+    // pop the stack and advance the cursor instead of inserting.
+    //
+    // We check the actual char in the buffer (not a stored col) so that
+    // characters typed between the pair don't invalidate the skip — the
+    // close char shifts right as the user types inside, but the buffer
+    // char check always finds it correctly.
+    if !in_replace
+        && !ed.vim.pending_closes.is_empty()
+        && let Some(&(pr, _pc, pch)) = ed.vim.pending_closes.last()
+        && ch == pch
+        && cursor.row == pr
+    {
+        let char_at_cursor =
+            buf_line(&ed.buffer, cursor.row).and_then(|l| l.chars().nth(cursor.col));
+        if char_at_cursor == Some(ch) {
+            ed.vim.pending_closes.pop();
+            // For `>` skip-over in HTML/XML: also run tag autoclose.
+            let filetype = ed.settings.filetype.clone();
+            let autoclose_tag = ed.settings.autoclose_tag;
+            if ch == '>' && autoclose_tag && is_html_filetype(&filetype) {
+                // Skip past the `>` that was auto-inserted.
+                let new_col = cursor.col + 1;
+                buf_set_cursor_rc(&mut ed.buffer, cursor.row, new_col);
+                // Now check for tag autoclose on the line up to new_col.
+                if let Some(line) = buf_line(&ed.buffer, cursor.row)
+                    && let Some(tag) = scan_tag_opener(&line, new_col.saturating_sub(1))
+                {
+                    let close_tag = format!("</{tag}>");
+                    let insert_pos = Position::new(cursor.row, new_col);
+                    ed.mutate_edit(Edit::InsertStr {
+                        at: insert_pos,
+                        text: close_tag,
+                    });
+                    // Cursor stays at new_col (between > and </tag>).
+                    buf_set_cursor_rc(&mut ed.buffer, cursor.row, new_col);
+                }
+            } else {
+                buf_set_cursor_rc(&mut ed.buffer, cursor.row, cursor.col + 1);
+            }
+            ed.push_buffer_cursor_to_textarea();
+            return true;
+        }
+    }
+
     if in_replace && cursor.col < line_chars {
+        // Replace mode: clear pending closes (edit outside the pair).
+        ed.vim.pending_closes.clear();
         ed.mutate_edit(Edit::DeleteRange {
             start: cursor,
             end: Position::new(cursor.row, cursor.col + 1),
@@ -1233,6 +1405,70 @@ pub(crate) fn insert_char_bridge<H: crate::types::Host>(
         });
         ed.mutate_edit(Edit::InsertChar { at: cursor, ch });
     } else if !try_dedent_close_bracket(ed, cursor, ch) {
+        // Normal insert. Check autopair first.
+        let autopair = ed.settings.autopair;
+        let filetype = ed.settings.filetype.clone();
+        let autoclose_tag = ed.settings.autoclose_tag;
+
+        let prev_char = if cursor.col > 0 {
+            buf_line(&ed.buffer, cursor.row).and_then(|l| l.chars().nth(cursor.col - 1))
+        } else {
+            None
+        };
+
+        if autopair {
+            if let Some(close) = autopair_close_for(ch, &filetype, prev_char) {
+                // Insert open char.
+                ed.mutate_edit(Edit::InsertChar { at: cursor, ch });
+                // Insert close char immediately after the open char.
+                // After inserting open at cursor, buffer cursor is at cursor.col+1.
+                let after = Position::new(cursor.row, cursor.col + 1);
+                ed.mutate_edit(Edit::InsertChar {
+                    at: after,
+                    ch: close,
+                });
+                // After inserting close, buffer cursor is at cursor.col+2.
+                // We want cursor between open and close: cursor.col+1.
+                let between_col = cursor.col + 1;
+                buf_set_cursor_rc(&mut ed.buffer, cursor.row, between_col);
+                // Record the close char for skip-over. We store the row and
+                // the close char; col is not tracked precisely because chars
+                // typed inside the pair shift the close right. The skip-over
+                // logic checks the actual buffer char at cursor instead.
+                ed.vim.pending_closes.push((cursor.row, between_col, close));
+                ed.push_buffer_cursor_to_textarea();
+                return true;
+            }
+
+            // Tag autoclose: `>` in HTML/XML family (no prior `<` pair).
+            // This fires when autopair did NOT match `>` (e.g. `>` was
+            // typed directly, not via a skip-over of an auto-inserted `>`).
+            if ch == '>' && autoclose_tag && is_html_filetype(&filetype) {
+                ed.mutate_edit(Edit::InsertChar { at: cursor, ch });
+                let new_col = cursor.col + 1;
+                // scan_tag_opener looks at the line up to (new_col-1), i.e.
+                // the char just inserted is at index new_col-1.
+                if let Some(line) = buf_line(&ed.buffer, cursor.row)
+                    && let Some(tag) = scan_tag_opener(&line, new_col.saturating_sub(1))
+                {
+                    let close_tag = format!("</{tag}>");
+                    let insert_pos = Position::new(cursor.row, new_col);
+                    ed.mutate_edit(Edit::InsertStr {
+                        at: insert_pos,
+                        text: close_tag,
+                    });
+                    // Cursor stays at new_col (between `>` and `</tag>`).
+                    buf_set_cursor_rc(&mut ed.buffer, cursor.row, new_col);
+                }
+                ed.push_buffer_cursor_to_textarea();
+                return true;
+            }
+        }
+
+        // Plain insert — do not clear the pending-closes stack here.
+        // The stack is cleared on cursor motion or mode change (Esc).
+        // Clearing here would prevent skip-over from firing after the
+        // user types content inside an auto-paired bracket.
         ed.mutate_edit(Edit::InsertChar { at: cursor, ch });
     }
     ed.push_buffer_cursor_to_textarea();
@@ -1241,6 +1477,8 @@ pub(crate) fn insert_char_bridge<H: crate::types::Host>(
 
 /// Insert a newline at the cursor, applying autoindent / smartindent and
 /// optionally continuing a line comment when `formatoptions` has `r`.
+/// Also handles open-pair-newline: Enter between `{|}` / `(|)` / `[|]`
+/// produces an indented block with the close on its own line.
 /// Returns `true`.
 pub(crate) fn insert_newline_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
@@ -1252,12 +1490,63 @@ pub(crate) fn insert_newline_bridge<H: crate::types::Host>(
         .unwrap_or_default()
         .to_string();
 
+    // Open-pair-newline: if autopair is on and the cursor is between a
+    // matching open/close bracket pair, split into two newlines so the
+    // close ends up on its own dedented line.
+    if ed.settings.autopair && !ed.vim.pending_closes.is_empty() {
+        // Check: char before cursor is an open bracket AND char at cursor
+        // is the matching close bracket (from our pending-closes stack).
+        let prev_char = if cursor.col > 0 {
+            prev_line.chars().nth(cursor.col - 1)
+        } else {
+            None
+        };
+        let next_char = prev_line.chars().nth(cursor.col);
+        let is_open_pair = matches!(
+            (prev_char, next_char),
+            (Some('{'), Some('}')) | (Some('('), Some(')')) | (Some('['), Some(']'))
+        );
+        if is_open_pair {
+            // The pending-closes stack refers to the close char at cursor.col.
+            // We clear it because the newline expansion moves the close.
+            ed.vim.pending_closes.clear();
+            // Compute indents: inner gets one extra unit, close gets base.
+            let base_indent: String = prev_line
+                .chars()
+                .take_while(|c| *c == ' ' || *c == '\t')
+                .collect();
+            let inner_indent = if ed.settings.expandtab {
+                let unit = if ed.settings.softtabstop > 0 {
+                    ed.settings.softtabstop
+                } else {
+                    ed.settings.shiftwidth
+                };
+                format!("{base_indent}{}", " ".repeat(unit))
+            } else {
+                format!("{base_indent}\t")
+            };
+            // Insert: \n<inner_indent>\n<base_indent>
+            // Then cursor lands after the first \n (inside the block).
+            let text = format!("\n{inner_indent}\n{base_indent}");
+            ed.mutate_edit(Edit::InsertStr { at: cursor, text });
+            // Move cursor to end of first new line (inner_indent line).
+            let new_row = cursor.row + 1;
+            let new_col = inner_indent.len();
+            buf_set_cursor_rc(&mut ed.buffer, new_row, new_col);
+            ed.push_buffer_cursor_to_textarea();
+            return true;
+        }
+    }
+
     // formatoptions `r`: continue comment on Enter in insert mode.
     let comment_cont = if ed.settings.formatoptions.contains('r') {
         continue_comment(&ed.buffer, &ed.settings, cursor.row)
     } else {
         None
     };
+
+    // Any Enter clears the pending-closes stack (cursor moved off the pair).
+    ed.vim.pending_closes.clear();
 
     let text = if let Some(cont) = comment_cont {
         // Comment continuation overrides autoindent: the indent is already
@@ -1422,12 +1711,14 @@ pub enum InsertDir {
 }
 
 /// Move the cursor one step in `dir`, breaking the undo group per
-/// `undo_break_on_motion`. Returns `false` (no mutation).
+/// `undo_break_on_motion`. Clears the autopair pending-closes stack (cursor
+/// moved off the pair). Returns `false` (no mutation).
 pub(crate) fn insert_arrow_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
     dir: InsertDir,
 ) -> bool {
     ed.sync_buffer_content_from_textarea();
+    ed.vim.pending_closes.clear();
     match dir {
         InsertDir::Left => {
             crate::motions::move_left(&mut ed.buffer, 1);
@@ -1450,11 +1741,12 @@ pub(crate) fn insert_arrow_bridge<H: crate::types::Host>(
 }
 
 /// Move the cursor to the start of the current line, breaking the undo group.
-/// Returns `false` (no mutation).
+/// Clears the autopair pending-closes stack. Returns `false` (no mutation).
 pub(crate) fn insert_home_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
 ) -> bool {
     ed.sync_buffer_content_from_textarea();
+    ed.vim.pending_closes.clear();
     crate::motions::move_line_start(&mut ed.buffer);
     break_undo_group_in_insert(ed);
     ed.push_buffer_cursor_to_textarea();
@@ -1462,11 +1754,12 @@ pub(crate) fn insert_home_bridge<H: crate::types::Host>(
 }
 
 /// Move the cursor to the end of the current line, breaking the undo group.
-/// Returns `false` (no mutation).
+/// Clears the autopair pending-closes stack. Returns `false` (no mutation).
 pub(crate) fn insert_end_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
 ) -> bool {
     ed.sync_buffer_content_from_textarea();
+    ed.vim.pending_closes.clear();
     crate::motions::move_line_end(&mut ed.buffer);
     break_undo_group_in_insert(ed);
     ed.push_buffer_cursor_to_textarea();
@@ -1635,11 +1928,13 @@ pub(crate) fn insert_paste_register_bridge<H: crate::types::Host>(
 
 /// Exit insert mode to Normal: finish the insert session, step the cursor one
 /// cell left (vim convention), record the `gi` target, and update the sticky
-/// column. Returns `true` (always consumed — even if no buffer mutation, the
-/// mode change itself is a meaningful step).
+/// column. Clears the autopair pending-closes stack. Returns `true` (always
+/// consumed — even if no buffer mutation, the mode change itself is a
+/// meaningful step).
 pub(crate) fn leave_insert_to_normal_bridge<H: crate::types::Host>(
     ed: &mut Editor<hjkl_buffer::Buffer, H>,
 ) -> bool {
+    ed.vim.pending_closes.clear();
     finish_insert_session(ed);
     ed.vim.mode = Mode::Normal;
     // Phase 6.3: keep current_mode in sync for callers that bypass step().

--- a/crates/hjkl-ex/src/setopt.rs
+++ b/crates/hjkl-ex/src/setopt.rs
@@ -74,6 +74,10 @@ pub fn all_setting_names() -> Vec<String> {
         "lbr".into(),
         "foldenable".into(),
         "fen".into(),
+        "autopair".into(),
+        "ap".into(),
+        "autoclose-tag".into(),
+        "act".into(),
     ]
 }
 
@@ -97,7 +101,7 @@ pub(crate) fn apply_set<H: Host>(
             hjkl_engine::types::SignColumnMode::Auto => "auto",
         };
         return ExEffect::Info(format!(
-            "shiftwidth={}  tabstop={}  softtabstop={}  textwidth={}  undolevels={}  timeoutlen={}  iskeyword=\"{}\"  expandtab={}  ignorecase={}  smartcase={}  wrapscan={}  autoindent={}  smartindent={}  undobreak={}  readonly={}  wrap={}  number={}  relativenumber={}  numberwidth={}  cursorline={}  cursorcolumn={}  signcolumn={}  foldcolumn={}  colorcolumn=\"{}\"  formatoptions=\"{}\"  filetype=\"{}\"  commentstring=\"{}\"",
+            "shiftwidth={}  tabstop={}  softtabstop={}  textwidth={}  undolevels={}  timeoutlen={}  iskeyword=\"{}\"  expandtab={}  ignorecase={}  smartcase={}  wrapscan={}  autoindent={}  smartindent={}  undobreak={}  readonly={}  wrap={}  number={}  relativenumber={}  numberwidth={}  cursorline={}  cursorcolumn={}  signcolumn={}  foldcolumn={}  colorcolumn=\"{}\"  formatoptions=\"{}\"  filetype=\"{}\"  commentstring=\"{}\"  autopair={}  autoclose-tag={}",
             s.shiftwidth,
             s.tabstop,
             s.softtabstop,
@@ -125,6 +129,8 @@ pub(crate) fn apply_set<H: Host>(
             s.formatoptions,
             s.filetype,
             s.commentstring,
+            if s.autopair { "on" } else { "off" },
+            if s.autoclose_tag { "on" } else { "off" },
         ));
     }
     for token in trimmed.split_whitespace() {
@@ -313,6 +319,8 @@ fn apply_set_token<H: Host>(
         // ex_dispatch.rs before hjkl-ex is consulted. Accept silently here so
         // hjkl-ex never emits an "unknown option" error if the token somehow
         // reaches this path.
+        "autopair" | "ap" => editor.settings_mut().autopair = value,
+        "autoclose-tag" | "act" => editor.settings_mut().autoclose_tag = value,
         "foldenable" | "fen" | "background" | "bg" => {}
         other => return Err(format!("unknown :set option `{other}`")),
     }


### PR DESCRIPTION
Closes #181

## Summary

- **Engine**: `autopair_close_for` table lookup in `insert_char_bridge`. On match: insert open+close, park cursor between, push to `VimState::pending_closes` stack.
- **Skip-over**: typed char == top of pending stack AND char at cursor in buffer matches → pop + advance (no insert). Works after typing content inside the pair (char position tracked by buffer, not stored col).
- **Invalidation**: `pending_closes` cleared on arrow/Home/End motion and on `leave_insert_to_normal_bridge` (Esc).
- **Open-pair-newline**: Enter between `{|}` / `(|)` / `[|]` inserts two newlines with close re-indented to base level; reuses `compute_enter_indent` unit arithmetic.
- **Tag autoclose** (html/xml/svg/jsx/tsx/vue/svelte): `>` press scans backward via `scan_tag_opener`; skips void elements and self-closing. Also fires on `>` skip-over in HTML so `<div>` typed naturally gets `</div>`.
- **Settings**: `autopair` (default on) and `autoclose_tag` (default on) added to `Settings`; wired through `apply_set_token` + `all_setting_names` + bare `:set` output.

## Scope decisions

- Tree-sitter suppression (inside string/comment) **skipped**: `hjkl-bonsai` scope query not trivially accessible from `insert_char_bridge`; filetype-naive autopair only. Follow-up as mentioned in issue.
- `<` → `>` pairing fires in HTML/XML/JSX/TSX/Vue/Svelte only; combined with tag autoclose via skip-over.

## Test plan

- [x] basic pair `(` → `(|)`
- [x] skip-over `("foo|")` typing `"` advances
- [x] apostrophe fallthrough (`don'` stays single)
- [x] cursor-motion clears stack (`(`, Left arrow, `)` → literal `)`)
- [x] tag autoclose `<div>` → `<div>|</div>` (html filetype)
- [x] void element no-close (`<br>` stays `<br>`)
- [x] self-closing no-close (`<Foo />` stays as typed)
- [x] `:set noautopair` disables
- [x] `:set noautoclose-tag` disables
- [x] open-pair-newline Enter between `{}` → indented block