### PR TITLE
fix(macro): replay must fall through to engine for insert-mode keys

### DIFF
--- a/apps/hjkl/src/app/chord_routing.rs
+++ b/apps/hjkl/src/app/chord_routing.rs
@@ -575,11 +575,17 @@ impl App {
                         // Re-feed each Input through route_chord_key by converting
                         // it back to a crossterm KeyEvent. During replay,
                         // is_replaying_macro() == true so the recorder hook skips
-                        // the replayed inputs.
+                        // the replayed inputs. Keys that the chord layer does not
+                        // consume (insert-mode chars, motions in normal mode that
+                        // don't bind to an app chord) must fall through to the
+                        // engine — same pattern as the live event-loop key path.
                         for input in inputs {
                             let ct_key = engine_input_to_key_event(input);
-                            if ct_key.code != KeyCode::Null {
-                                self.route_chord_key(ct_key);
+                            if ct_key.code == KeyCode::Null {
+                                continue;
+                            }
+                            if !self.route_chord_key(ct_key) {
+                                hjkl_vim_tui::handle_key(&mut self.active_mut().editor, ct_key);
                             }
                         }
                         self.active_mut().editor.end_macro_replay();

--- a/apps/hjkl/src/app/tests/marks_registers.rs
+++ b/apps/hjkl/src/app/tests/marks_registers.rs
@@ -413,6 +413,58 @@ fn record_macro_a_j_motion_replay_plays() {
 }
 
 #[test]
+fn record_macro_a_insert_text_esc_motion_replays_full() {
+    // Repro for: qa A test <Esc> 0 j q  → @a should re-execute the entire
+    // sequence on the next line. Reported bug: replay only enters insert
+    // mode at EOL and stops (text + esc + motion not replayed).
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "line0\nline1\nline2\nline3");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(
+        &mut app,
+        &[
+            ck('q'),
+            ck('a'), // start recording into 'a'
+            ck('A'), // append at end of line → Insert mode
+            ck('t'),
+            ck('e'),
+            ck('s'),
+            ck('t'),
+            key(KeyCode::Esc), // back to Normal
+            ck('0'),           // start of line
+            ck('j'),           // down one
+            ck('q'),           // stop recording
+        ],
+    );
+    assert!(!app.active().editor.is_recording_macro());
+    assert_eq!(
+        app.active().editor.buffer().lines()[0],
+        "line0test",
+        "recording itself must append 'test' to line0"
+    );
+    assert_eq!(
+        app.active().editor.cursor(),
+        (1, 0),
+        "after recording, cursor must be at row 1, col 0"
+    );
+
+    macro_key_seq(&mut app, &[ck('@'), ck('a')]);
+    assert!(!app.active().editor.is_replaying_macro());
+    assert_eq!(
+        app.active().editor.buffer().lines()[1],
+        "line1test",
+        "@a must re-execute A+test on line1"
+    );
+    assert_eq!(
+        app.active().editor.cursor(),
+        (2, 0),
+        "@a must end with cursor at row 2, col 0 (0 then j)"
+    );
+}
+
+#[test]
 fn at_at_repeats_last_macro() {
     // Record `qa j q`, play `@a`, then `@@` re-plays same macro.
     let mut app = App::new(None, false, None, None).unwrap();

--- a/crates/hjkl-compat-oracle/corpus/tier2_macros.toml
+++ b/crates/hjkl-compat-oracle/corpus/tier2_macros.toml
@@ -46,3 +46,16 @@ initial_cursor = [0, 0]
 keys = "@z"
 expected_buffer = "hello\n"
 expected_cursor = [0, 0]
+
+# Record A+text+Esc+motion into 'a' on line0, then replay on line1.
+# Regression: app-layer `@{reg}` chord replay was dropping every key after
+# the first because route_chord_key returned false for insert-mode chars
+# and the caller discarded the return value (engine path works fine; this
+# corpus case pins the engine semantics so future refactors can't drift).
+[[cases]]
+name = "macro_record_A_text_esc_motion_replays_full"
+initial_buffer = "line0\nline1\nline2\nline3\n"
+initial_cursor = [0, 0]
+keys = "qaAtest<Esc>0jq@a"
+expected_buffer = "line0test\nline1test\nline2\nline3\n"
+expected_cursor = [2, 0]


### PR DESCRIPTION
## Summary

The app-level `@{reg}` chord replay only called `route_chord_key` for each recorded input and discarded the return value. Insert-mode chars (and any other key not bound to a chord) silently dropped, so a macro like `qa A test <Esc> 0 j q` would replay `A`, enter Insert at EOL, and stop — `test`, `<Esc>`, `0`, and `j` were never delivered to the engine.

Mirror the `macro_key_seq` test helper and the live event-loop key path: when `route_chord_key` returns false, fall through to `hjkl_vim_tui::handle_key`.

## Test plan

- [x] New regression test `record_macro_a_insert_text_esc_motion_replays_full` in `apps/hjkl/src/app/tests/marks_registers.rs` — fails before fix, passes after
- [x] New oracle case `macro_record_A_text_esc_motion_replays_full` in `crates/hjkl-compat-oracle/corpus/tier2_macros.toml` pinning the engine-path semantics
- [x] `cargo test -p hjkl` — 741 pass
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` clean