### PR TITLE
fix(macro): record insert-mode keys via dispatch_insert_key

### DIFF
--- a/apps/hjkl/src/app/event_loop.rs
+++ b/apps/hjkl/src/app/event_loop.rs
@@ -93,6 +93,17 @@ impl App {
         use crossterm::event::{KeyCode, KeyModifiers};
         use hjkl_engine::InsertDir;
 
+        // Recorder hook — this path bypasses begin_step / end_step (the
+        // engine's standard recorder site), so insert-mode chars must be
+        // pushed here when a macro is recording. Skipped during replay so
+        // played-back inputs don't append to the active recording.
+        if self.active().editor.is_recording_macro() && !self.active().editor.is_replaying_macro() {
+            let input = hjkl_engine_tui::crossterm_to_input(key);
+            if input.key != hjkl_engine::Key::Null {
+                self.active_mut().editor.record_input(input);
+            }
+        }
+
         // `Ctrl-R` two-key sequence: the previous key armed the register
         // selector. The next printable char names the register to paste.
         // Any non-printable key cancels (mirrors vim behaviour).

--- a/apps/hjkl/src/app/tests/marks_registers.rs
+++ b/apps/hjkl/src/app/tests/marks_registers.rs
@@ -465,6 +465,59 @@ fn record_macro_a_insert_text_esc_motion_replays_full() {
 }
 
 #[test]
+fn record_macro_a_comma_text_esc_j0_replays() {
+    // User scenario: qaA, this is a test<Esc>j0q  → @a
+    // Expected: append ", this is a test" to current line then move down/start.
+    // Actual bug report: replay went into insert at EOL then literally typed "j0".
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "line0\nline1\nline2");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(
+        &mut app,
+        &[
+            ck('q'),
+            ck('a'),
+            ck('A'),
+            ck(','),
+            ck(' '),
+            ck('t'),
+            ck('h'),
+            ck('i'),
+            ck('s'),
+            ck(' '),
+            ck('i'),
+            ck('s'),
+            ck(' '),
+            ck('a'),
+            ck(' '),
+            ck('t'),
+            ck('e'),
+            ck('s'),
+            ck('t'),
+            key(KeyCode::Esc),
+            ck('j'),
+            ck('0'),
+            ck('q'),
+        ],
+    );
+    assert!(!app.active().editor.is_recording_macro());
+    assert_eq!(
+        app.active().editor.buffer().lines()[0],
+        "line0, this is a test",
+        "recording itself must append the text"
+    );
+
+    macro_key_seq(&mut app, &[ck('@'), ck('a')]);
+    assert_eq!(
+        app.active().editor.buffer().lines()[1],
+        "line1, this is a test",
+        "@a must re-append the text on line1"
+    );
+}
+
+#[test]
 fn at_at_repeats_last_macro() {
     // Record `qa j q`, play `@a`, then `@@` re-plays same macro.
     let mut app = App::new(None, false, None, None).unwrap();

--- a/apps/hjkl/src/app/tests/mod.rs
+++ b/apps/hjkl/src/app/tests/mod.rs
@@ -492,9 +492,16 @@ fn ck(c: char) -> KeyEvent {
 
 fn macro_key_seq(app: &mut App, keys: &[KeyEvent]) {
     for &k in keys {
-        // route_chord_key returns false for unrecognised keys; forward to engine.
+        // route_chord_key returns false for unrecognised keys; forward to the
+        // same fallback the live event loop uses — dispatch_insert_key in
+        // Insert mode, hjkl_vim_tui::handle_key elsewhere — so test paths
+        // exercise the production recorder behaviour exactly.
         if !app.route_chord_key(k) {
-            hjkl_vim_tui::handle_key(&mut app.active_mut().editor, k);
+            if app.active().editor.vim_mode() == VimMode::Insert {
+                app.dispatch_insert_key(k);
+            } else {
+                hjkl_vim_tui::handle_key(&mut app.active_mut().editor, k);
+            }
         }
         app.sync_viewport_from_editor();
     }


### PR DESCRIPTION
## Summary

The live event loop dispatches Insert-mode keys through `dispatch_insert_key`, which calls `Editor::insert_*` primitives directly and bypasses `begin_step` / `end_step`. The engine-level recorder hook in `end_step` therefore never fired for insert-mode keys, so any macro recorded with text-entry segments (e.g. `qaA, this is a test<Esc>q`) stored only the mode-switching keys (`A`, `<Esc>`). Replay then re-entered Insert at EOL and silently dropped the missing chars, exactly as the bug report described.

The original test harness masked the bug by falling back to `hjkl_vim_tui::handle_key` (which DOES go through `dispatch_input` + `end_step` + recorder), so `macro_key_seq` recorded everything correctly even though production didn't.

## Fix

1. `dispatch_insert_key` gets its own recorder hook — push the converted `Input` onto `recording_keys` when `is_recording_macro() && !is_replaying_macro()`.
2. `macro_key_seq` now mirrors the live event loop: `dispatch_insert_key` in Insert mode, `hjkl_vim_tui::handle_key` elsewhere. Future tests exercise the production code path.

## Test plan

- [x] New regression test `record_macro_a_comma_text_esc_j0_replays` reproduces the exact user scenario; before fix the register stored \`\"Aj0\"\` and replay inserted \`\"j0\"\` literally; after fix register stores \`\"A, this is a test<Esc>j0\"\` and replay produces the expected buffer
- [x] All 742 \`hjkl\` tests pass
- [x] \`cargo fmt --all\` + \`cargo clippy --workspace --all-targets -- -D warnings\` clean

## Note on the compat oracle

This bug was not caught by the oracle because the oracle drives the engine directly via \`hjkl_vim::dispatch_input\` — it doesn't exercise the App layer's \`dispatch_insert_key\` shortcut. The oracle measures engine correctness, not App routing. Worth filing a follow-up to add an app-layer oracle pass for production-path coverage.