### PR TITLE
fix(macro): record insert keys at handle_keypress Insert block (not dispatch_insert_key)

### DIFF
--- a/apps/hjkl/src/app/event_loop.rs
+++ b/apps/hjkl/src/app/event_loop.rs
@@ -93,16 +93,10 @@ impl App {
         use crossterm::event::{KeyCode, KeyModifiers};
         use hjkl_engine::InsertDir;
 
-        // Recorder hook — this path bypasses begin_step / end_step (the
-        // engine's standard recorder site), so insert-mode chars must be
-        // pushed here when a macro is recording. Skipped during replay so
-        // played-back inputs don't append to the active recording.
-        if self.active().editor.is_recording_macro() && !self.active().editor.is_replaying_macro() {
-            let input = hjkl_engine_tui::crossterm_to_input(key);
-            if input.key != hjkl_engine::Key::Null {
-                self.active_mut().editor.record_input(input);
-            }
-        }
+        // Macro recording for keys that reach this dispatcher happens upstream
+        // in `handle_keypress`'s Insert-mode block (the single hook there
+        // covers consume-and-return Continue paths AND fall-through paths so
+        // we don't double-record). Don't add a hook here.
 
         // `Ctrl-R` two-key sequence: the previous key armed the register
         // selector. The next printable char names the register to paste.
@@ -500,6 +494,24 @@ impl App {
         // This block intercepts specific keys in insert mode to
         // manage the completion popup, before forwarding to the engine.
         if self.active().editor.vim_mode() == VimMode::Insert {
+            // Recorder hook for Insert-mode keys that this block consumes
+            // (printable chars routed to insert_char, popup-open Backspace
+            // routed to insert_backspace, etc). Those paths return
+            // KeyOutcome::Continue without ever reaching dispatch_insert_key
+            // or the engine FSM step wrapper, so the engine end_step
+            // recorder doesn't fire. Skipped during replay so played-back
+            // inputs don't append to the active recording. Keys that
+            // fall through this block to dispatch_insert_key get their
+            // recording from dispatch_insert_key's own hook.
+            if self.active().editor.is_recording_macro()
+                && !self.active().editor.is_replaying_macro()
+            {
+                let input = hjkl_engine_tui::crossterm_to_input(key);
+                if input.key != hjkl_engine::Key::Null {
+                    self.active_mut().editor.record_input(input);
+                }
+            }
+
             // <C-x><C-o> manual omni-completion trigger.
             if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('x') {
                 self.pending_ctrl_x = true;

--- a/apps/hjkl/src/app/tests/mod.rs
+++ b/apps/hjkl/src/app/tests/mod.rs
@@ -491,16 +491,22 @@ fn ck(c: char) -> KeyEvent {
 }
 
 fn macro_key_seq(app: &mut App, keys: &[KeyEvent]) {
+    use crate::app::event_loop::KeyOutcome;
     for &k in keys {
-        // route_chord_key returns false for unrecognised keys; forward to the
-        // same fallback the live event loop uses — dispatch_insert_key in
-        // Insert mode, hjkl_vim_tui::handle_key elsewhere — so test paths
-        // exercise the production recorder behaviour exactly.
-        if !app.route_chord_key(k) {
-            if app.active().editor.vim_mode() == VimMode::Insert {
-                app.dispatch_insert_key(k);
-            } else {
-                hjkl_vim_tui::handle_key(&mut app.active_mut().editor, k);
+        // Mirror the live event loop exactly: handle_keypress first (which
+        // itself calls route_chord_key + the Insert-mode completion-aware
+        // inline dispatcher), and only fall through to dispatch_insert_key /
+        // hjkl_vim_tui::handle_key when handle_keypress returns FallThrough.
+        // Anything less leaves the test exercising a different code path than
+        // production and masks bugs in the handle_keypress inline dispatcher.
+        match app.handle_keypress(k) {
+            KeyOutcome::Break | KeyOutcome::Continue => {}
+            KeyOutcome::FallThrough => {
+                if app.active().editor.vim_mode() == VimMode::Insert {
+                    app.dispatch_insert_key(k);
+                } else {
+                    hjkl_vim_tui::handle_key(&mut app.active_mut().editor, k);
+                }
             }
         }
         app.sync_viewport_from_editor();


### PR DESCRIPTION
## Summary

#218 added a recorder hook to `dispatch_insert_key`, but the live event loop's `handle_keypress` has its own Insert-mode completion-aware dispatcher (the popup-handling block) that calls `Editor::insert_char` / `insert_backspace` directly and returns `KeyOutcome::Continue`. Those keys never reach `dispatch_insert_key` or the engine FSM step wrapper, so neither hook fires and every printable insert-mode keystroke is silently dropped from the recorded macro.

The test harness masked this because `macro_key_seq` called `route_chord_key` directly instead of going through `handle_keypress`, so its fall-through path always reached `dispatch_insert_key`. With the harness fixed to match prod, the user-reported scenario reproduces deterministically.

## Fix

1. Move the recorder hook to the top of `handle_keypress`'s Insert-mode block. One site covers both the consume-and-return-Continue branches AND the fall-through keys (Esc, Enter, etc.) before they reach `dispatch_insert_key`.
2. Remove the `dispatch_insert_key` recorder hook so fall-through keys aren't double-recorded.
3. `macro_key_seq` test helper now drives through `handle_keypress` and only falls through to `dispatch_insert_key` / `hjkl_vim_tui::handle_key` on `KeyOutcome::FallThrough` — matches the production main loop exactly.

## Test plan

- [x] `record_macro_a_comma_text_esc_j0_replays` reproduces the user-reported scenario end-to-end (`qaA, this is a test<Esc>j0q` → `@a`)
- [x] All 3 macro integration tests pass: `record_macro_a_j_motion_replay_plays`, `record_macro_a_insert_text_esc_motion_replays_full`, `record_macro_a_comma_text_esc_j0_replays`
- [x] All 742 `hjkl` tests pass
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` clean