### PR TITLE
fix(app): auto-detect filetype on file open so gcc / comment-continue work

### DIFF
--- a/apps/hjkl/src/app/mod.rs
+++ b/apps/hjkl/src/app/mod.rs
@@ -457,6 +457,14 @@ pub(super) fn build_slot(
     if let Some(ref p) = path {
         let outcome = syntax.set_language_for_path(buffer_id, p);
         let _ = outcome; // Outcome handled via poll_grammar_loads for Loading.
+        // Mirror the language detection onto the engine's filetype setting
+        // so filetype-aware features (comment-continuation, `gcc` toggle,
+        // `:set commentstring` defaults, future modeline knobs) light up
+        // automatically on file open. Cheap synchronous extension lookup;
+        // no grammar load.
+        if let Some(lang) = syntax.language_name_for_path(p) {
+            editor.set_filetype(&lang);
+        }
     }
 
     let (vp_top, vp_height) = {

--- a/apps/hjkl/src/app/tests/marks_registers.rs
+++ b/apps/hjkl/src/app/tests/marks_registers.rs
@@ -518,6 +518,56 @@ fn record_macro_a_comma_text_esc_j0_replays() {
 }
 
 #[test]
+fn gcc_toggles_comment_on_current_line_via_app_layer() {
+    // User report: `gcc` doesn't toggle line comment in the live binary.
+    // Drive through the same path the event loop uses (handle_keypress →
+    // route_chord_key → engine via FallThrough).
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "let x = 1;\nlet y = 2;");
+    app.active_mut().editor.set_filetype("rust");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(&mut app, &[ck('g'), ck('c'), ck('c')]);
+    assert_eq!(
+        app.active().editor.buffer().lines()[0],
+        "// let x = 1;",
+        "gcc must toggle a comment marker onto line 0"
+    );
+}
+
+#[test]
+fn opening_rust_file_auto_sets_filetype_so_gcc_works() {
+    // User report: opening a .rs file from the CLI and pressing `gcc`
+    // does nothing. Root cause: build_slot never called set_filetype, so
+    // toggle_comment_range took the no-known-syntax early return. This
+    // test drives the production file-open path end-to-end.
+    let dir = std::env::temp_dir().join(format!("hjkl-gcc-filetype-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let file_path = dir.join("a.rs");
+    std::fs::write(&file_path, "let x = 1;\nlet y = 2;\n").unwrap();
+
+    let mut app = App::new(Some(file_path.clone()), false, None, None).unwrap();
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    assert_eq!(
+        app.active().editor.settings().filetype,
+        "rust",
+        "opening a .rs file must seed the editor's filetype to \"rust\""
+    );
+
+    macro_key_seq(&mut app, &[ck('g'), ck('c'), ck('c')]);
+    assert_eq!(
+        app.active().editor.buffer().lines()[0],
+        "// let x = 1;",
+        "gcc on a freshly-opened .rs file must toggle a comment marker"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn at_at_repeats_last_macro() {
     // Record `qa j q`, play `@a`, then `@@` re-plays same macro.
     let mut app = App::new(None, false, None, None).unwrap();

--- a/apps/hjkl/src/syntax.rs
+++ b/apps/hjkl/src/syntax.rs
@@ -107,6 +107,15 @@ impl SyntaxLayer {
         self.inner.set_language_for_path(id, path)
     }
 
+    /// Resolve a path to its canonical language name (e.g. `"rust"` for
+    /// `foo.rs`) without loading any grammar. Returns `None` for unknown
+    /// extensions. Used to seed `Editor::set_filetype` on file open so
+    /// filetype-aware features (`gcc`, comment continuation, …) light up
+    /// regardless of whether the grammar itself is installed yet.
+    pub fn language_name_for_path(&self, path: &Path) -> Option<String> {
+        self.inner.directory().name_for_path(path)
+    }
+
     /// Poll all in-flight grammar loads. Call once per tick.
     pub fn poll_pending_loads(&mut self) -> Vec<LoadEvent> {
         self.inner.poll_pending_loads()

--- a/crates/hjkl-lang/src/lib.rs
+++ b/crates/hjkl-lang/src/lib.rs
@@ -97,6 +97,18 @@ impl LanguageDirectory {
 
     // ── Async-friendly API (UI-thread callers) ────────────────────────────────
 
+    /// Resolve a path to its canonical language name (e.g. `"rust"` for
+    /// `foo.rs`). Returns `None` for unknown / extensionless paths.
+    ///
+    /// Cheap (extension lookup against the bonsai manifest) and synchronous
+    /// — does not load any grammar. Use this when you only need the
+    /// language identifier (e.g. for `:set filetype=`, commentstring
+    /// resolution, LSP language-id mapping) and don't care about the
+    /// grammar object.
+    pub fn name_for_path(&self, path: &Path) -> Option<String> {
+        self.registry.name_for_path(path).map(|s| s.to_string())
+    }
+
     /// Async-friendly resolution by path. Returns immediately; never blocks
     /// on clone+compile. See module-level docs for the three fast paths.
     pub fn request_for_path(&self, path: &Path) -> GrammarRequest {

--- a/crates/hjkl-syntax/src/lib.rs
+++ b/crates/hjkl-syntax/src/lib.rs
@@ -958,6 +958,13 @@ impl SyntaxLayer {
     /// let dir = Arc::new(LanguageDirectory::new().unwrap());
     /// let layer = SyntaxLayer::new(theme, dir);
     /// ```
+    /// Borrow the shared language directory. Useful for cheap
+    /// path-to-language-name lookups (e.g. `name_for_path`) without
+    /// triggering any grammar load.
+    pub fn directory(&self) -> &Arc<LanguageDirectory> {
+        &self.directory
+    }
+
     pub fn new(theme: Arc<dyn Theme + Send + Sync>, directory: Arc<LanguageDirectory>) -> Self {
         let worker = SyntaxWorker::spawn(Arc::clone(&theme), Arc::clone(&directory));
         Self {


### PR DESCRIPTION
## Summary

PR #214 (comment continuation) and PR #215 (gcc toggle) both added a `Settings::filetype` field and made their behaviour conditional on it being non-empty — but no code path in the app populated it. Opening `foo.rs` from the CLI left `settings.filetype = \"\"`, so `toggle_comment_range` hit the no-known-syntax early return and \`gcc\` silently no-op'd. Same for comment continuation on Enter / o / O, \`:set commentstring\` defaults, and any future filetype-aware feature.

## Fix

In \`build_slot\`, after \`syntax.set_language_for_path\` resolves the grammar request, call \`SyntaxLayer::language_name_for_path\` (new synchronous cheap-lookup wrapper around \`LanguageDirectory::name_for_path\`, also new) and forward the resolved name into \`editor.set_filetype\`.

### New surface
- \`hjkl_lang::LanguageDirectory::name_for_path\` — extension-only lookup against the embedded bonsai manifest; no grammar load.
- \`hjkl_syntax::SyntaxLayer::directory\` — borrow the shared \`LanguageDirectory\` for callers that need the cheap APIs.
- \`apps/hjkl\` \`SyntaxLayer\` wrapper exposes \`language_name_for_path\` so the app layer doesn't depend on \`hjkl_lang\` directly for this.

## Test plan

- [x] New regression test \`opening_rust_file_auto_sets_filetype_so_gcc_works\` drives the production \`App::new\` + file-read + \`build_slot\` path against a real \`.rs\` file under \`env::temp_dir()\`; fails before fix, passes after
- [x] All 744 \`hjkl\` tests pass
- [x] \`cargo fmt --all\` + \`cargo clippy --workspace --all-targets -- -D warnings\` clean