### PR TITLE
fix(autopair): suppress pairing on the third of a triple-quote run

### DIFF
--- a/apps/hjkl/tests/autopair.rs
+++ b/apps/hjkl/tests/autopair.rs
@@ -457,3 +457,63 @@ fn open_pair_newline_brace() {
         "cursor should be on the middle (indented) line, got row {row}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Triple-quote / triple-backtick guard
+// ---------------------------------------------------------------------------
+
+/// Typing three backticks must produce exactly three (markdown code-fence),
+/// not four. Regression for user report: `` ``` `` left a 4th backtick
+/// because the autopair fired on the third keystroke.
+#[test]
+fn triple_backtick_does_not_autopair_third() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "`"); // 1st → autopair → `|`
+    feed_insert(&mut ed, "`"); // 2nd → skip-over → ``|
+    feed_insert(&mut ed, "`"); // 3rd → triple-quote guard → bare insert → ```|
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["```"],
+        "expected three backticks, got {lines:?}"
+    );
+    let (row, col) = cursor(&ed);
+    assert_eq!(
+        (row, col),
+        (0, 3),
+        "cursor should be after the three backticks"
+    );
+}
+
+/// Same guard for `"""` (Python triple-quoted strings).
+#[test]
+fn triple_double_quote_does_not_autopair_third() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "\"");
+    feed_insert(&mut ed, "\"");
+    feed_insert(&mut ed, "\"");
+    assert_eq!(
+        buf_lines(&ed),
+        vec!["\"\"\""],
+        "expected three double-quotes"
+    );
+    assert_eq!(cursor(&ed), (0, 3));
+}
+
+/// Same guard for `\u{27}\u{27}\u{27}` (rare but seen in some templating).
+#[test]
+fn triple_single_quote_does_not_autopair_third() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "\u{27}");
+    feed_insert(&mut ed, "\u{27}");
+    feed_insert(&mut ed, "\u{27}");
+    assert_eq!(
+        buf_lines(&ed),
+        vec!["\u{27}\u{27}\u{27}"],
+        "expected three single quotes"
+    );
+    assert_eq!(cursor(&ed), (0, 3));
+}

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -1222,17 +1222,48 @@ pub(crate) fn break_undo_group_in_insert<H: crate::types::Host>(
 /// when no pairing applies.
 ///
 /// Rules:
-/// - `(` → `)`, `[` → `]`, `{` → `}`, `"` → `"`, `` ` `` → `` ` `` always.
+/// - `(` → `)`, `[` → `]`, `{` → `}` always.
+/// - `"` → `"` and `` ` `` → `` ` `` always, EXCEPT when the previous two
+///   characters are the same quote — typing the third `` ` `` of a markdown
+///   code-fence or the third `"` of a Python triple-quoted string must
+///   emit a bare quote (no close) so the result is `` ``` `` / `"""` and
+///   not `` ```` `` / `""""`.
 /// - `<` → `>` only for HTML/XML family filetypes.
 /// - `'` → `'` unless the character immediately before the cursor is
-///   `[A-Za-z]` (prose apostrophe guard — "don't" stays "don't").
-fn autopair_close_for(ch: char, filetype: &str, prev_char: Option<char>) -> Option<char> {
+///   `[A-Za-z]` (prose apostrophe guard — "don't" stays "don't"), AND the
+///   same triple-quote guard as `"` / `` ` ``.
+fn autopair_close_for(
+    ch: char,
+    filetype: &str,
+    prev_char: Option<char>,
+    prev2_char: Option<char>,
+) -> Option<char> {
+    // Triple-quote guard — applies to ", `, and ' (the three quote chars
+    // that get same-char pairing). When the previous two characters are
+    // both this same quote, treat the third keystroke as a bare insert so
+    // the user lands on `` ``` `` / `"""` / `'''` without a stray fourth
+    // quote dangling after the cursor.
+    let is_triple_quote_third =
+        matches!(ch, '"' | '`' | '\'') && prev_char == Some(ch) && prev2_char == Some(ch);
+
     match ch {
         '(' => Some(')'),
         '[' => Some(']'),
         '{' => Some('}'),
-        '"' => Some('"'),
-        '`' => Some('`'),
+        '"' => {
+            if is_triple_quote_third {
+                None
+            } else {
+                Some('"')
+            }
+        }
+        '`' => {
+            if is_triple_quote_third {
+                None
+            } else {
+                Some('`')
+            }
+        }
         '<' => {
             if is_html_filetype(filetype) {
                 Some('>')
@@ -1241,6 +1272,9 @@ fn autopair_close_for(ch: char, filetype: &str, prev_char: Option<char>) -> Opti
             }
         }
         '\'' => {
+            if is_triple_quote_third {
+                return None;
+            }
             // Prose guard: skip pairing when the previous char is a letter
             // (covers "don't", "it's", etc.).
             if prev_char.map(|c| c.is_ascii_alphabetic()).unwrap_or(false) {
@@ -1410,14 +1444,24 @@ pub(crate) fn insert_char_bridge<H: crate::types::Host>(
         let filetype = ed.settings.filetype.clone();
         let autoclose_tag = ed.settings.autoclose_tag;
 
-        let prev_char = if cursor.col > 0 {
-            buf_line(&ed.buffer, cursor.row).and_then(|l| l.chars().nth(cursor.col - 1))
-        } else {
-            None
+        let (prev_char, prev2_char) = {
+            let line = buf_line(&ed.buffer, cursor.row).unwrap_or_default();
+            let chars: Vec<char> = line.chars().collect();
+            let p1 = if cursor.col > 0 {
+                chars.get(cursor.col - 1).copied()
+            } else {
+                None
+            };
+            let p2 = if cursor.col > 1 {
+                chars.get(cursor.col - 2).copied()
+            } else {
+                None
+            };
+            (p1, p2)
         };
 
         if autopair {
-            if let Some(close) = autopair_close_for(ch, &filetype, prev_char) {
+            if let Some(close) = autopair_close_for(ch, &filetype, prev_char, prev2_char) {
                 // Insert open char.
                 ed.mutate_edit(Edit::InsertChar { at: cursor, ch });
                 // Insert close char immediately after the open char.


### PR DESCRIPTION
## Summary

User report: typing three backticks (markdown code-fence) produces four. 1st keystroke autopairs, 2nd skip-overs the auto-inserted close, 3rd hits `autopair_close_for` again and inserts another pair — leaving a stray quote past the cursor.

## Fix

`autopair_close_for` gains a triple-quote guard: when `ch` is `"`, `` ` ``, or `'` and **both** preceding characters are the same quote, return `None` so the third keystroke is a bare insert. Applies only to the three same-char-pair quotes (which are the only ones that can form a triple without disturbing the prose-apostrophe or HTML-tag rules).

`insert_char_bridge` now precomputes both `prev_char` and `prev2_char` so the guard can see two chars back.

## Test plan

- [x] `triple_backtick_does_not_autopair_third` — pins the user-reported case
- [x] `triple_double_quote_does_not_autopair_third` — Python `\"\"\"` docstrings
- [x] `triple_single_quote_does_not_autopair_third` — covers `'''` for templating/Python
- [x] All 747 `hjkl` tests pass
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` clean