### PR TITLE
feat(autopair): expand markdown/doc-comment code fence on Enter

### DIFF
--- a/apps/hjkl/tests/autopair.rs
+++ b/apps/hjkl/tests/autopair.rs
@@ -517,3 +517,78 @@ fn triple_single_quote_does_not_autopair_third() {
     );
     assert_eq!(cursor(&ed), (0, 3));
 }
+
+// ---------------------------------------------------------------------------
+// Code-fence Enter expansion
+// ---------------------------------------------------------------------------
+
+/// Typing ```rust then Enter must produce three lines: opener, blank
+/// middle, closer — with the cursor parked on the middle line.
+#[test]
+fn code_fence_with_lang_expands_on_enter() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "`");
+    feed_insert(&mut ed, "`");
+    feed_insert(&mut ed, "`");
+    feed_insert(&mut ed, "r");
+    feed_insert(&mut ed, "u");
+    feed_insert(&mut ed, "s");
+    feed_insert(&mut ed, "t");
+    feed_insert(&mut ed, "\n");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["```rust".to_string(), String::new(), "```".to_string()],
+        "expected three lines with cursor on middle, got {lines:?}"
+    );
+    let (row, col) = cursor(&ed);
+    assert_eq!(
+        (row, col),
+        (1, 0),
+        "cursor must land on the blank middle line"
+    );
+}
+
+/// Bare ``` (no language tag) on Enter must NOT expand — could be either
+/// an opener or a closer and we don't track parity.
+#[test]
+fn bare_triple_backtick_does_not_expand_on_enter() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "`");
+    feed_insert(&mut ed, "`");
+    feed_insert(&mut ed, "`");
+    feed_insert(&mut ed, "\n");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec!["```".to_string(), String::new()],
+        "bare fence + Enter must not expand, got {lines:?}"
+    );
+}
+
+/// Indented fence (e.g. inside a list item) preserves indentation on the
+/// opener, blank, and closer lines.
+#[test]
+fn indented_code_fence_preserves_indent_on_expand() {
+    let mut ed = editor("", "");
+    feed(&mut ed, "i");
+    feed_insert(&mut ed, "    ```rust\n");
+    let lines = buf_lines(&ed);
+    assert_eq!(
+        lines,
+        vec![
+            "    ```rust".to_string(),
+            "    ".to_string(),
+            "    ```".to_string(),
+        ],
+        "expected indented fence pair, got {lines:?}"
+    );
+    let (row, col) = cursor(&ed);
+    assert_eq!(
+        (row, col),
+        (1, 4),
+        "cursor must land on the indented blank middle line"
+    );
+}

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -1287,6 +1287,42 @@ fn autopair_close_for(
     }
 }
 
+/// Detect a markdown / doc-comment code-fence opener on the current line.
+///
+/// Returns `Some(fence)` (the backtick run that should be used as the
+/// closing fence) when:
+/// - The cursor is at the end of the visible line (`cursor_col` equals the
+///   line's char count).
+/// - The line, after leading whitespace, begins with 3+ backticks followed
+///   by a non-empty language tag matching `[A-Za-z0-9_+-]+` and nothing
+///   else (no trailing space, no extra text).
+///
+/// The language tag requirement is deliberate: a bare ` ``` ` could be
+/// either an opener OR a closer, and we don't track fence parity here.
+/// Requiring a tag means we only fire when the user is clearly opening a
+/// fence (` ```rust `, ` ```ts `, etc.).
+fn detect_code_fence_opener(line: &str, cursor_col: usize) -> Option<String> {
+    if cursor_col != line.chars().count() {
+        return None;
+    }
+    let trimmed = line.trim_start();
+    let backtick_run = trimmed.chars().take_while(|c| *c == '`').count();
+    if backtick_run < 3 {
+        return None;
+    }
+    let rest = &trimmed[backtick_run..];
+    if rest.is_empty() {
+        return None;
+    }
+    let all_lang_chars = rest
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '+' || c == '-');
+    if !all_lang_chars {
+        return None;
+    }
+    Some("`".repeat(backtick_run))
+}
+
 /// Filetypes that get HTML/XML-family treatment (`<` pairing + tag autoclose).
 fn is_html_filetype(ft: &str) -> bool {
     matches!(
@@ -1580,6 +1616,31 @@ pub(crate) fn insert_newline_bridge<H: crate::types::Host>(
             ed.push_buffer_cursor_to_textarea();
             return true;
         }
+    }
+
+    // Code-fence expansion: line content is ` ``` ` (3+ backticks) followed
+    // by a non-empty language tag, cursor sits at end of line → insert the
+    // matching closing fence on the line below and park the cursor on a
+    // blank middle line. Matches the open-pair-newline shape but for
+    // markdown / doc-comment code blocks. Gated on a language tag because
+    // a bare ` ``` ` could just as easily be a closing fence — we'd need
+    // full document parity tracking to handle that safely, which v1
+    // doesn't have.
+    if ed.settings.autopair
+        && let Some(fence) = detect_code_fence_opener(&prev_line, cursor.col)
+    {
+        ed.vim.pending_closes.clear();
+        let base_indent: String = prev_line
+            .chars()
+            .take_while(|c| *c == ' ' || *c == '\t')
+            .collect();
+        let text = format!("\n{base_indent}\n{base_indent}{fence}");
+        ed.mutate_edit(Edit::InsertStr { at: cursor, text });
+        let new_row = cursor.row + 1;
+        let new_col = base_indent.chars().count();
+        buf_set_cursor_rc(&mut ed.buffer, new_row, new_col);
+        ed.push_buffer_cursor_to_textarea();
+        return true;
     }
 
     // formatoptions `r`: continue comment on Enter in insert mode.


### PR DESCRIPTION
## Summary

QoL follow-up to PR #221 (triple-quote guard). When the user types a code-fence opener with a language tag (` ```rust `, ` ```ts `, ` ```bash `) and presses Enter, insert the matching closing fence on the line below and park the cursor on a blank middle line:

```
```rust
|
```
```

Mirrors the open-pair-newline shape (`{|}` → indented block) but for markdown / doc-comment code blocks.

## Implementation

- new `detect_code_fence_opener` helper — recognises a line whose trimmed content starts with 3+ backticks followed by an alphanumeric/`+`/`_`/`-` language tag and nothing else, with the cursor at end of line
- `insert_newline_bridge` consults the helper before falling back to the normal autoindent / `formatoptions=r` continuation paths
- gated on a **non-empty language tag** because a bare ` ``` ` could be either an opener or a closer — we don't track fence parity here, so the tag is the only safe signal

## Test plan

- [x] `code_fence_with_lang_expands_on_enter` — user's stated case
- [x] `bare_triple_backtick_does_not_expand_on_enter` — guards the closer-collision risk
- [x] `indented_code_fence_preserves_indent_on_expand` — covers fences inside list items / doc comments
- [x] All 750 `hjkl` tests pass
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` clean