### PR TITLE
fix(bonsai): handle injections.scm with directive-only language

### DIFF
--- a/crates/hjkl-bonsai/src/highlighter.rs
+++ b/crates/hjkl-bonsai/src/highlighter.rs
@@ -652,22 +652,25 @@ impl Highlighter {
             return parent_spans;
         };
 
-        // Find the capture indices for @injection.language and @injection.content.
+        // Find the capture indices. `@injection.content` is required (the
+        // injection has to know WHICH bytes to recurse into). `@injection.language`
+        // is optional — many grammars (HTML's style/script, Markdown's html_block,
+        // etc.) use a pattern-level `(#set! injection.language "foo")` directive
+        // instead of a capture, in which case the language name is read from
+        // `Query::property_settings` per match below.
         let lang_idx = inj_query
             .capture_names()
             .iter()
-            .position(|n| *n == INJ_LANG_CAPTURE);
-        let content_idx = inj_query
+            .position(|n| *n == INJ_LANG_CAPTURE)
+            .map(|i| i as u32);
+        let Some(content_idx) = inj_query
             .capture_names()
             .iter()
-            .position(|n| *n == INJ_CONTENT_CAPTURE);
-
-        let (Some(lang_idx), Some(content_idx)) = (lang_idx, content_idx) else {
-            // This grammar's injections.scm doesn't use the standard captures.
+            .position(|n| *n == INJ_CONTENT_CAPTURE)
+        else {
+            // No content capture at all — nothing to inject.
             return parent_spans;
         };
-
-        let lang_idx = lang_idx as u32;
         let content_idx = content_idx as u32;
 
         let Some(tree) = self.tree.as_ref() else {
@@ -681,17 +684,16 @@ impl Highlighter {
             let mut matches = cursor.matches(inj_query, tree.root_node(), source);
 
             while let Some(m) = matches.next() {
-                // Each match may have both @injection.language and
-                // @injection.content captures, possibly in either order.
-                // Alternatively, the pattern may set injection.language as a
-                // `(#set! injection.language "foo")` directive — used by
-                // tree-sitter-markdown for (inline) → markdown_inline,
-                // (html_block) → html, (minus_metadata) → yaml, etc.
+                // Each match may have @injection.content + optional
+                // @injection.language captures, in any order. Alternatively
+                // (and commonly), the pattern uses a
+                // `(#set! injection.language "foo")` directive — picked up
+                // by the property_settings fallback below.
                 let mut lang_name: Option<String> = None;
                 let mut content_range: Option<Range<usize>> = None;
 
                 for cap in m.captures {
-                    if cap.index == lang_idx {
+                    if Some(cap.index) == lang_idx {
                         let s = cap.node.start_byte();
                         let e = cap.node.end_byte();
                         if s < e
@@ -857,21 +859,22 @@ impl Highlighter {
             return parent_spans;
         };
 
-        // Find the capture indices for @injection.language and @injection.content.
+        // `@injection.content` required; `@injection.language` optional
+        // (often supplied by `(#set! injection.language "foo")` directive).
+        // See the matching block in `highlight_with_injections` for full
+        // resolution policy notes.
         let lang_idx = inj_query
             .capture_names()
             .iter()
-            .position(|n| *n == INJ_LANG_CAPTURE);
-        let content_idx = inj_query
+            .position(|n| *n == INJ_LANG_CAPTURE)
+            .map(|i| i as u32);
+        let Some(content_idx) = inj_query
             .capture_names()
             .iter()
-            .position(|n| *n == INJ_CONTENT_CAPTURE);
-
-        let (Some(lang_idx), Some(content_idx)) = (lang_idx, content_idx) else {
+            .position(|n| *n == INJ_CONTENT_CAPTURE)
+        else {
             return parent_spans;
         };
-
-        let lang_idx = lang_idx as u32;
         let content_idx = content_idx as u32;
 
         let Some(tree) = self.tree.as_ref() else {
@@ -893,7 +896,7 @@ impl Highlighter {
                 let mut content_range: Option<Range<usize>> = None;
 
                 for cap in m.captures {
-                    if cap.index == lang_idx {
+                    if Some(cap.index) == lang_idx {
                         let s = cap.node.start_byte();
                         let e = cap.node.end_byte();
                         if s < e

--- a/crates/hjkl-bonsai/tests/injection.rs
+++ b/crates/hjkl-bonsai/tests/injection.rs
@@ -312,3 +312,79 @@ fn markdown_inline_injection_directive_form_fires_in_range_variant() {
         "scoped variant must also fire the directive-form resolver; got: {names:?}"
     );
 }
+
+/// HTML's injections.scm uses ONLY directive-form `(#set! injection.language
+/// "css")` / `(... "javascript")` with no `@injection.language` capture at
+/// all. Regression for a bug where the highlighter early-returned when the
+/// query had no language capture, skipping the directive-form fallback and
+/// leaving CSS/JS inside `<style>`/`<script>` unhighlighted.
+#[test]
+#[ignore = "network + compiler: fetches html grammar"]
+fn html_directive_only_injection_query_fires_resolver() {
+    use std::cell::RefCell;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (registry, meta) = registry_and_meta();
+    let loader = make_loader(&tmp);
+
+    let html_grammar = load_grammar("html", &loader, &registry, &meta);
+    assert!(
+        html_grammar.injections_scm().is_some(),
+        "html grammar must ship an injections.scm",
+    );
+    // Verify the query is genuinely directive-only — if upstream html ever
+    // adds an @injection.language capture this assertion will turn this
+    // test into a less-useful overlap with the markdown directive test;
+    // failing here is the signal to update.
+    let inj = html_grammar.injections_scm().unwrap();
+    assert!(
+        !inj.contains("@injection.language"),
+        "test assumes html injections.scm has no @injection.language capture; \
+         got:\n{inj}"
+    );
+
+    let source: &[u8] = b"<html><head><style>body { color: red; }</style></head></html>";
+
+    let asked: RefCell<Vec<String>> = RefCell::new(Vec::new());
+    let mut highlighter = Highlighter::new(html_grammar).unwrap();
+    let _ = highlighter.highlight_with_injections(source, |name: &str| {
+        asked.borrow_mut().push(name.to_string());
+        None
+    });
+
+    let names = asked.borrow();
+    assert!(
+        names.iter().any(|n| n == "css"),
+        "directive-only injection query must still fire the resolver; got: {names:?}"
+    );
+}
+
+/// Same as above but for the scoped variant — must produce identical
+/// behaviour so a viewport-restricted render doesn't silently lose
+/// directive-form injections.
+#[test]
+#[ignore = "network + compiler: fetches html grammar"]
+fn html_directive_only_injection_query_fires_in_range_variant() {
+    use std::cell::RefCell;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let (registry, meta) = registry_and_meta();
+    let loader = make_loader(&tmp);
+
+    let html_grammar = load_grammar("html", &loader, &registry, &meta);
+    let source: &[u8] = b"<html><head><style>body { color: red; }</style></head></html>";
+
+    let asked: RefCell<Vec<String>> = RefCell::new(Vec::new());
+    let mut highlighter = Highlighter::new(html_grammar).unwrap();
+    highlighter.parse_initial(source);
+    let _ = highlighter.highlight_range_with_injections(source, 0..source.len(), |name: &str| {
+        asked.borrow_mut().push(name.to_string());
+        None
+    });
+
+    let names = asked.borrow();
+    assert!(
+        names.iter().any(|n| n == "css"),
+        "scoped variant must also fire directive-form resolver; got: {names:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Highlighter early-returned when an `injections.scm` had no `@injection.language` **capture** — but tree-sitter-html (and any grammar whose injection rules use only `(#set! injection.language \"...\")` directives) doesn't need such a capture. The early return killed every injection in those grammars, including HTML's `style_element` → CSS and `script_element` → JavaScript.

User report: opening a `.html` file, content inside `<style>` rendered with no syntax highlighting.

## Fix

Make `@injection.language` optional in both walkers (`highlight_with_injections` + `highlight_range_with_injections`). Keep `@injection.content` as the required capture; the directive-form `property_settings` fallback then resolves the language name per match as before.

## Why the existing tests missed it

The two `markdown_inline_injection_directive_form_fires_*` tests exercise a grammar (markdown) whose `injections.scm` has BOTH a capture (for fenced-code-block language tags) AND directives (for `inline` / `html_block` / `yaml` / `toml`). Because the capture exists, the early-return condition never triggered. The bug only surfaces in directive-only queries.

## Test plan

- [x] Two new `html_directive_only_injection_query_fires_*` tests in `crates/hjkl-bonsai/tests/injection.rs` — gated on `#[ignore]` (network + compiler) like the existing injection tests
- [x] Verified both tests FAIL against the prior code (stash + run + restore)
- [x] All 80 `hjkl-bonsai` tests pass with fix
- [x] All 750 `hjkl` tests pass
- [x] `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` clean