### PR TITLE
fix(app): route gc through AfterOp reducer + fire visual gc on selection

### DIFF
--- a/apps/hjkl/src/app/chord_routing.rs
+++ b/apps/hjkl/src/app/chord_routing.rs
@@ -282,23 +282,47 @@ impl App {
                             }
                             _ => {}
                         }
-                        // Chord-init case-ops: intercept u/U/~/q and set
-                        // reducer AfterOp instead of calling after_g (which
-                        // would set engine Pending::Op). This keeps the full
-                        // gU/gu/g~/gq op-pending path inside the reducer.
+                        // Chord-init g-prefixed operators: intercept u/U/~/q/c.
+                        //
+                        // - In Normal mode: set the App-level AfterOp reducer
+                        //   (gives gU/gu/g~/gq/gc/gcc the same timeout-safe
+                        //   pending path as d/y/c — fixes intermittent gcc
+                        //   no-ops caused by the 1000ms engine chord-timeout
+                        //   firing between keystrokes when the chord went
+                        //   through the engine).
+                        // - In Visual modes: fire the operator immediately on
+                        //   the active selection (no additional keystroke
+                        //   needed — that's the vim semantics for visual gc /
+                        //   gu / gU / g~ / gq).
                         let case_op_kind = match ch {
                             'u' => Some(hjkl_vim::OperatorKind::Lowercase),
                             'U' => Some(hjkl_vim::OperatorKind::Uppercase),
                             '~' => Some(hjkl_vim::OperatorKind::ToggleCase),
                             'q' => Some(hjkl_vim::OperatorKind::Reflow),
+                            'c' => Some(hjkl_vim::OperatorKind::Comment),
                             _ => None,
                         };
                         if let Some(op) = case_op_kind {
-                            self.pending_state = Some(hjkl_vim::PendingState::AfterOp {
-                                op,
-                                count1: count,
-                                inner_count: 0,
-                            });
+                            use hjkl_engine::VimMode;
+                            let mode = self.active().editor.vim_mode();
+                            if matches!(
+                                mode,
+                                VimMode::Visual | VimMode::VisualLine | VimMode::VisualBlock
+                            ) {
+                                self.dispatch_action(
+                                    crate::keymap_actions::AppAction::VisualOp {
+                                        op,
+                                        count: count as u32,
+                                    },
+                                    count as u32,
+                                );
+                            } else {
+                                self.pending_state = Some(hjkl_vim::PendingState::AfterOp {
+                                    op,
+                                    count1: count,
+                                    inner_count: 0,
+                                });
+                            }
                             return true;
                         }
                         // All other g-chords: delegate to engine.

--- a/apps/hjkl/src/app/tests/marks_registers.rs
+++ b/apps/hjkl/src/app/tests/marks_registers.rs
@@ -557,6 +557,111 @@ fn gcc_on_doc_comment_uncomments_via_app_layer() {
 }
 
 #[test]
+fn gc_in_visual_line_toggles_selection_via_app_layer() {
+    // Visual `gc` must fire toggle_comment_range on the active selection
+    // immediately — no second key required. Before the routing fix, gc in
+    // visual went through engine.after_g which set Pending::Op{Comment}
+    // and stalled waiting for a motion that visual mode never delivers.
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "let x = 1;\nlet y = 2;\nlet z = 3;");
+    app.active_mut().editor.set_filetype("rust");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    // V → visual-line, j → extend down, gc → toggle.
+    macro_key_seq(&mut app, &[ck('V'), ck('j'), ck('g'), ck('c')]);
+    let lines = app.active().editor.buffer().lines().to_vec();
+    assert_eq!(
+        lines[0], "// let x = 1;",
+        "visual gc must comment line 0; got {lines:?}"
+    );
+    assert_eq!(
+        lines[1], "// let y = 2;",
+        "visual gc must comment line 1; got {lines:?}"
+    );
+    assert_eq!(
+        lines[2], "let z = 3;",
+        "visual gc must NOT touch line 2 (outside selection); got {lines:?}"
+    );
+}
+
+#[test]
+fn gc_in_visual_charwise_toggles_selection_via_app_layer() {
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "let x = 1;\nlet y = 2;");
+    app.active_mut().editor.set_filetype("rust");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(&mut app, &[ck('v'), ck('j'), ck('g'), ck('c')]);
+    let lines = app.active().editor.buffer().lines().to_vec();
+    assert_eq!(lines[0], "// let x = 1;");
+    assert_eq!(lines[1], "// let y = 2;");
+}
+
+#[test]
+fn gcc_then_gcc_round_trips_after_routing_fix() {
+    // Direct regression for the user-reported intermittent gcc no-op.
+    // After the routing fix, gc/gcc go through the App-level AfterOp
+    // reducer instead of engine Pending::Op, so the 1000ms engine chord-
+    // timeout can no longer drop the third `c` and reroute it into the
+    // bare-`c` Change operator path.
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "let x = 1;\nlet y = 2;");
+    app.active_mut().editor.set_filetype("rust");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(&mut app, &[ck('g'), ck('c'), ck('c')]);
+    assert_eq!(app.active().editor.buffer().lines()[0], "// let x = 1;");
+    // Critical: no engine pending leak between invocations.
+    assert!(!app.active().editor.is_chord_pending());
+    assert!(app.pending_state.is_none());
+
+    macro_key_seq(&mut app, &[ck('g'), ck('c'), ck('c')]);
+    assert_eq!(
+        app.active().editor.buffer().lines()[0],
+        "let x = 1;",
+        "second gcc must uncomment after the routing fix"
+    );
+    assert!(!app.active().editor.is_chord_pending());
+}
+
+#[test]
+fn gcc_with_count_3_toggles_3_lines_via_app_layer() {
+    // `3gcc` — comment 3 lines starting at cursor.
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "a\nb\nc\nd\ne");
+    app.active_mut().editor.set_filetype("rust");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(&mut app, &[ck('3'), ck('g'), ck('c'), ck('c')]);
+    let lines = app.active().editor.buffer().lines().to_vec();
+    assert_eq!(lines[0], "// a");
+    assert_eq!(lines[1], "// b");
+    assert_eq!(lines[2], "// c");
+    assert_eq!(lines[3], "d", "line 3 must stay outside the count range");
+    assert_eq!(lines[4], "e");
+}
+
+#[test]
+fn gc_with_motion_j_toggles_2_lines_via_app_layer() {
+    // `gcj` — comment current line plus one line down (motion j).
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "a\nb\nc");
+    app.active_mut().editor.set_filetype("rust");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(&mut app, &[ck('g'), ck('c'), ck('j')]);
+    let lines = app.active().editor.buffer().lines().to_vec();
+    assert_eq!(lines[0], "// a");
+    assert_eq!(lines[1], "// b");
+    assert_eq!(lines[2], "c");
+}
+
+#[test]
 fn gcc_on_indented_doc_comment_via_app_layer() {
     let mut app = App::new(None, false, None, None).unwrap();
     seed_buffer(&mut app, "    /// indented doc\nfn foo() {}");


### PR DESCRIPTION
Two fixes for the gc / gcc family — resolves the intermittent gcc no-op and the previously broken visual gc.

## Normal-mode gcc: timeout-safe routing

`AfterGChord` previously called `editor.after_g('c', count)` → engine `Pending::Op{Comment}` and relied on the engine-pending bypass to deliver the third `c`. That path is gated by `begin_step`'s 1000ms `timeout_len` — a pause >1s between the second and third keystroke clears engine pending, drops the third `c` into the bare-`c` keymap arm → `BeginPendingAfterOp{Change}` → wrong operator.

Fix: extend the existing case_op_kind match (already u/U/~/q) with `'c' → OperatorKind::Comment`. App-level `AfterOp` reducer handles double-char + motion + text-object dispatch with **no timeout in the loop**.

## Visual gc / gu / gU / g~ / gq fire on selection

Same site: when `vim_mode` is Visual / VisualLine / VisualBlock, dispatch `VisualOp{op}` immediately instead of setting pending — matches vim semantics where visual operators don't wait for a follow-up keystroke. Unblocks the dead-code Comment arms in `engine_actions.rs` that no keymap binding could previously reach.

## Test plan

5 new app-layer tests pin the matrix:
- `gcc_then_gcc_round_trips_after_routing_fix` — direct regression for the reported intermittent no-op
- `gc_in_visual_line_toggles_selection_via_app_layer`
- `gc_in_visual_charwise_toggles_selection_via_app_layer`
- `gcc_with_count_3_toggles_3_lines_via_app_layer`
- `gc_with_motion_j_toggles_2_lines_via_app_layer`

All 765 `hjkl` tests pass; `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` clean.