### PR TITLE
fix(syntax): clear stale spans on row-count change

### DIFF
--- a/apps/hjkl/src/app/event_loop.rs
+++ b/apps/hjkl/src/app/event_loop.rs
@@ -5,6 +5,7 @@ use crossterm::{
     execute,
 };
 use hjkl_engine::{CursorShape, Host, VimMode};
+use hjkl_engine_tui::EditorRatatuiExt;
 use hjkl_keymap::{Chord as KmChord, KeyEvent as KmKeyEvent};
 use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io::Stdout;
@@ -1305,6 +1306,18 @@ impl App {
                     let edits = self.active_mut().editor.take_content_edits();
                     if !edits.is_empty() {
                         self.syntax.apply_edits(buffer_id, &edits);
+                        // Clear stale spans on row-count change — see
+                        // matching block in `App::sync_after_engine_mutation`
+                        // for rationale (renderer indexes buffer_spans by
+                        // row; old rows map to wrong new rows after a shift).
+                        let row_count_changed = edits
+                            .iter()
+                            .any(|e| e.old_end_position.0 != e.new_end_position.0);
+                        if row_count_changed {
+                            self.active_mut()
+                                .editor
+                                .install_ratatui_syntax_spans(Vec::new());
+                        }
                     }
                     self.lsp_notify_change_active();
                     self.recompute_and_install();

--- a/apps/hjkl/src/app/mod.rs
+++ b/apps/hjkl/src/app/mod.rs
@@ -801,6 +801,23 @@ impl App {
             // current one — any cache older than this gen is stale for these
             // rows and should show blank until the worker returns.
             let new_dg = self.active().editor.buffer().dirty_gen();
+            // If any edit changed the row count, the entire installed
+            // buffer_spans cache (indexed by row) is invalid — old rows
+            // map to new rows after the shift. Renderer would otherwise
+            // paint last-frame's spans at the wrong line until the syntax
+            // worker returns a fresh result. Clear immediately so the
+            // intermediate frames render uncoloured rather than mis-
+            // coloured. Same-row edits (typing within one line) don't
+            // need this — buffer_spans rows still map to the right line,
+            // even if individual span byte-ranges are momentarily stale.
+            let row_count_changed = edits
+                .iter()
+                .any(|e| e.old_end_position.0 != e.new_end_position.0);
+            if row_count_changed {
+                self.active_mut()
+                    .editor
+                    .install_ratatui_syntax_spans(Vec::new());
+            }
             for edit in &edits {
                 let start_row = edit.start_position.0 as usize;
                 let end_row =


### PR DESCRIPTION
User report: after Enter inserts a new line, hex-color preview blocks and other spans render at wrong rows for a frame or more — old-row spans paint at new rows after the shift.

## Root cause

`Editor::buffer_spans` is indexed by row. `install_syntax_spans` only replaces it when the syntax worker delivers a fresh result. Between keystroke and worker response the renderer indexes `buffer_spans` by NEW row but finds OLD-row entries → visually shifted.

Same-row edits (typing within one line) don't trip the bug — row indices still align; only within-line byte ranges momentarily lag, which is invisible.

## Fix

On every batch of content edits, check whether any `InputEdit.old_end_position.0 != new_end_position.0` (row shifted). If yes, immediately install an empty `Vec` to clear buffer_spans. Renderer paints uncoloured rows for at most one frame until worker returns — much better than visibly misaligned highlights.

Applied at both content-edit drain sites: `App::sync_after_engine_mutation` (keymap dispatch) and the main loop's after-key hook in `event_loop.rs` (engine FSM dispatch).

All 773 `hjkl` tests pass; fmt + clippy clean.