### PR TITLE
perf(syntax): fully-sync bonsai + render/save/paste fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 !Cargo.lock
 **/*.rs.bk
+*.gz
 *.swp
 .DS_Store
 /target

--- a/apps/hjkl/src/app/buffer_ops.rs
+++ b/apps/hjkl/src/app/buffer_ops.rs
@@ -1,6 +1,5 @@
 use hjkl_buffer::Buffer;
 use hjkl_engine::{Editor, Host, MarkJump, Options};
-use hjkl_engine_tui::EditorRatatuiExt;
 use std::path::PathBuf;
 
 use super::{App, DiskState, STATUS_LINE_HEIGHT};
@@ -38,58 +37,8 @@ impl App {
             vp.width = size.0;
             vp.height = size.1.saturating_sub(STATUS_LINE_HEIGHT);
         }
-        let buffer_id = self.active().buffer_id;
-        let (vp_top, vp_height) = {
-            let vp = self.active().editor.host().viewport();
-            (vp.top_row, vp.height as usize)
-        };
-
-        // T3: Re-install cached spans from the last completed viewport parse
-        // for this slot — gives the first frame after a buffer switch correct
-        // highlight colours while the fresh parse runs in the background.
-        // Drop the cache if dirty_gen has advanced (stale spans would show wrong highlights).
-        let cached_spans_installed = {
-            let current_dg = self.slots[idx].editor.buffer().dirty_gen();
-            // Check staleness: if the viewport cache exists, its dirty_gen must match.
-            let any_stale = self.slots[idx]
-                .viewport_render_output
-                .as_ref()
-                .is_some_and(|o| o.key.0 != current_dg);
-            if any_stale {
-                self.slots[idx].viewport_render_output = None;
-                false
-            } else {
-                let has_viewport = self.slots[idx].viewport_render_output.is_some();
-                if has_viewport {
-                    // Install the diag signs from the viewport cache (most recent live parse).
-                    if let Some(ref vp) = self.slots[idx].viewport_render_output {
-                        let signs = vp.signs.clone();
-                        self.slots[idx].diag_signs = signs;
-                    }
-                    if let Some(ref vp) = self.slots[idx].viewport_render_output {
-                        let spans = vp.spans.clone();
-                        self.slots[idx].editor.install_ratatui_syntax_spans(spans);
-                    }
-                }
-                has_viewport
-            }
-        };
-
-        // Fall back to the cheap preview render when no valid cache.
-        if !cached_spans_installed
-            && let Some(out) = self.syntax.preview_render(
-                buffer_id,
-                self.active().editor.buffer(),
-                vp_top,
-                vp_height,
-            )
-        {
-            self.active_mut()
-                .editor
-                .install_ratatui_syntax_spans(out.spans);
-        }
-
-        self.active_mut().last_recompute_key = None;
+        // recompute_and_install runs render_viewport sync (post fully-sync
+        // refactor) — no need for a preview_render warm-up paint.
         self.recompute_and_install();
         self.refresh_git_signs_force();
     }
@@ -164,8 +113,6 @@ impl App {
             slot.diag_signs.clear();
             slot.git_signs.clear();
             slot.last_git_dirty_gen = None;
-            slot.last_recompute_key = None;
-            slot.viewport_render_output = None;
             slot.saved_hash = 0;
             slot.saved_len = 0;
             slot.disk_mtime = None;
@@ -265,8 +212,6 @@ impl App {
             slot.diag_signs.clear();
             slot.git_signs.clear();
             slot.last_git_dirty_gen = None;
-            slot.last_recompute_key = None;
-            slot.viewport_render_output = None;
             slot.saved_hash = 0;
             slot.saved_len = 0;
             slot.disk_mtime = None;

--- a/apps/hjkl/src/app/event_loop.rs
+++ b/apps/hjkl/src/app/event_loop.rs
@@ -1316,8 +1316,6 @@ impl App {
                         self.active_mut()
                             .editor
                             .shift_syntax_spans_for_edits(&edits);
-                        let active_idx = self.focused_slot_idx();
-                        self.shift_cached_render_output_spans_for_slot(active_idx, &edits);
                     }
                     self.lsp_notify_change_active();
                     self.recompute_and_install();
@@ -1380,8 +1378,6 @@ impl App {
                                     self.active_mut()
                                         .editor
                                         .shift_syntax_spans_for_edits(&edits);
-                                    let aidx = self.focused_slot_idx();
-                                    self.shift_cached_render_output_spans_for_slot(aidx, &edits);
                                 }
                                 self.lsp_notify_change_active();
                                 self.pending_recompute = true;

--- a/apps/hjkl/src/app/ex_dispatch.rs
+++ b/apps/hjkl/src/app/ex_dispatch.rs
@@ -148,14 +148,12 @@ impl App {
             match rest.trim() {
                 "dark" => {
                     self.syntax.set_theme(Arc::new(DotFallbackTheme::dark()));
-                    self.active_mut().last_recompute_key = None;
                     self.recompute_and_install();
                     self.bus.info("background=dark");
                     return;
                 }
                 "light" => {
                     self.syntax.set_theme(Arc::new(DotFallbackTheme::light()));
-                    self.active_mut().last_recompute_key = None;
                     self.recompute_and_install();
                     self.bus.info("background=light");
                     return;
@@ -640,18 +638,11 @@ impl App {
                 git_signs: Vec::new(),
                 last_git_dirty_gen: None,
                 last_git_refresh_at: std::time::Instant::now(),
-                last_recompute_at: std::time::Instant::now() - std::time::Duration::from_secs(1),
-                last_recompute_key: None,
                 saved_hash: 0,
                 saved_len: 0,
                 disk_mtime: None,
                 disk_len: None,
                 disk_state: super::DiskState::Synced,
-                viewport_render_output: None,
-                last_sync_viewport_key: None,
-                installed_spans_dg: None,
-                installed_rows: None,
-                dirty_rows_log: Vec::new(),
             };
             slot.snapshot_saved();
             self.slots.push(slot);
@@ -723,18 +714,11 @@ impl App {
                 git_signs: Vec::new(),
                 last_git_dirty_gen: None,
                 last_git_refresh_at: std::time::Instant::now(),
-                last_recompute_at: std::time::Instant::now() - std::time::Duration::from_secs(1),
-                last_recompute_key: None,
                 saved_hash: 0,
                 saved_len: 0,
                 disk_mtime: None,
                 disk_len: None,
                 disk_state: super::DiskState::Synced,
-                viewport_render_output: None,
-                last_sync_viewport_key: None,
-                installed_spans_dg: None,
-                installed_rows: None,
-                dirty_rows_log: Vec::new(),
             };
             slot.snapshot_saved();
             self.slots.push(slot);
@@ -818,14 +802,19 @@ impl App {
                 false
             }
             Some(p) => {
-                let lines = self.slots[idx].editor.buffer().lines();
-                let content = if lines.is_empty() {
-                    String::new()
-                } else {
-                    let mut s = lines.join("\n");
-                    s.push('\n');
-                    s
-                };
+                // Reuse the per-dirty_gen Arc<String> from content_joined() so
+                // saves share the same allocation that LSP / git / syntax / dirty
+                // signature paths already paid for. Was Buffer::lines().join()
+                // which re-cloned every line (162k allocs on a 162k-row buffer).
+                // Write in two pieces so the trailing newline doesn't force a
+                // full-buffer clone just to push a byte.
+                use hjkl_engine::Query;
+                use std::io::Write;
+                let joined = self.slots[idx].editor.buffer().content_joined();
+                let body: &[u8] = joined.as_bytes();
+                let needs_trailing_nl = !body.is_empty() && !body.ends_with(b"\n");
+                let line_count = self.slots[idx].editor.buffer().line_count() as usize;
+                let byte_count = body.len() + usize::from(needs_trailing_nl);
                 // Create parent dir(s) if missing so writing into a fresh
                 // path like ~/.config/hjkl/config.toml works first try.
                 if let Some(parent) = p.parent()
@@ -836,10 +825,16 @@ impl App {
                     self.bus.error(format!("E: {}: {e}", parent.display()));
                     return false;
                 }
-                match std::fs::write(&p, &content) {
+                let write_result = (|| -> std::io::Result<()> {
+                    let mut f = std::fs::File::create(&p)?;
+                    f.write_all(body)?;
+                    if needs_trailing_nl {
+                        f.write_all(b"\n")?;
+                    }
+                    Ok(())
+                })();
+                match write_result {
                     Ok(()) => {
-                        let line_count = lines.len();
-                        let byte_count = content.len();
                         self.bus.info(format!(
                             "\"{}\" {}L, {}B written",
                             p.display(),
@@ -1055,22 +1050,11 @@ impl App {
         let outcome = self.syntax.set_language_for_path(buffer_id, &path);
         let _ = outcome.is_known(); // Suppresses unused-result warning.
         self.syntax.reset(buffer_id);
-        self.active_mut().last_recompute_key = None;
+
         self.active_mut()
             .editor
             .install_ratatui_syntax_spans(Vec::new());
-        let (vp_top, vp_height) = {
-            let vp = self.active().editor.host().viewport();
-            (vp.top_row, vp.height as usize)
-        };
-        if let Some(out) =
-            self.syntax
-                .preview_render(buffer_id, self.active().editor.buffer(), vp_top, vp_height)
-        {
-            self.active_mut()
-                .editor
-                .install_ratatui_syntax_spans(out.spans);
-        }
+        // recompute_and_install runs render_viewport sync — no preview warm-up needed.
         self.recompute_and_install();
         self.active_mut().snapshot_saved();
         self.refresh_git_signs_force();
@@ -1154,25 +1138,13 @@ impl App {
                         let outcome = self.syntax.set_language_for_path(buffer_id, &path);
                         let _ = outcome.is_known(); // Suppresses unused-result warning.
                         self.syntax.reset(buffer_id);
-                        self.slots[idx].last_recompute_key = None;
+
                         if idx == self.focused_slot_idx() {
                             self.slots[idx]
                                 .editor
                                 .install_ratatui_syntax_spans(Vec::new());
-                            let (vp_top, vp_height) = {
-                                let vp = self.slots[idx].editor.host().viewport();
-                                (vp.top_row, vp.height as usize)
-                            };
-                            if let Some(out) = self.syntax.preview_render(
-                                buffer_id,
-                                self.slots[idx].editor.buffer(),
-                                vp_top,
-                                vp_height,
-                            ) {
-                                self.slots[idx]
-                                    .editor
-                                    .install_ratatui_syntax_spans(out.spans);
-                            }
+                            // recompute_and_install runs render_viewport sync — no
+                            // preview warm-up needed.
                             self.recompute_and_install();
                             self.refresh_git_signs_force();
                         }
@@ -1379,18 +1351,11 @@ impl App {
                 git_signs: Vec::new(),
                 last_git_dirty_gen: None,
                 last_git_refresh_at: std::time::Instant::now(),
-                last_recompute_at: std::time::Instant::now() - std::time::Duration::from_secs(1),
-                last_recompute_key: None,
                 saved_hash: 0,
                 saved_len: 0,
                 disk_mtime: None,
                 disk_len: None,
                 disk_state: super::DiskState::Synced,
-                viewport_render_output: None,
-                last_sync_viewport_key: None,
-                installed_spans_dg: None,
-                installed_rows: None,
-                dirty_rows_log: Vec::new(),
             };
             slot.snapshot_saved();
             self.slots.push(slot);

--- a/apps/hjkl/src/app/mod.rs
+++ b/apps/hjkl/src/app/mod.rs
@@ -207,30 +207,23 @@ pub struct App {
     pub(crate) preview_highlighters:
         std::sync::Mutex<std::collections::HashMap<String, hjkl_bonsai::Highlighter>>,
     /// Toggled by `:syntax on|off`. When false, the bonsai syntax pipeline
-    /// is bypassed: spans stay empty, no submit_render fires, and
+    /// is bypassed: spans stay empty, no render_viewport fires, and
     /// `recompute_and_install` returns immediately. Re-enabling re-attaches
     /// the language for every slot's path and triggers a fresh recompute.
     /// Default `true` — vim parity.
     pub syntax_enabled: bool,
+    /// Cache for `render::search_count` — keyed by buffer id, dirty_gen,
+    /// cursor, and pattern text so the same result is returned on every
+    /// frame between input/edits. Without this the status line scans the
+    /// whole document on every render — 50 %+ of CPU on big files with an
+    /// active `/` pattern (per samply).
+    pub(crate) search_count_cache: std::cell::RefCell<Option<SearchCountCache>>,
     /// Set when an event handler decided a `recompute_and_install` is
     /// needed but deferred it to coalesce. The main event loop runs the
     /// recompute once after the event-drain loop ends, so a burst of
     /// mouse-scroll events fires one sync query instead of N.
     pub(crate) pending_recompute: bool,
-    pub last_recompute_us: u128,
-    pub last_install_us: u128,
     pub last_signature_us: u128,
-    pub last_git_us: u128,
-    pub last_perf: crate::syntax::PerfBreakdown,
-    /// Counters surfaced in `:perf` so the user can verify cache ratios.
-    pub recompute_hits: u64,
-    pub recompute_throttled: u64,
-    pub recompute_runs: u64,
-    /// Count of async syntax results dropped because their tagged
-    /// buffer_id no longer matches the active buffer (race: parse
-    /// queued before a tab/buffer switch). Surfaced in `:perf` and
-    /// asserted in the regression test on the install path.
-    pub syntax_stale_drops: u64,
     /// User config (bundled defaults + optional XDG overrides). Tests
     /// receive `Config::default()` (the bundled values); main wires the
     /// XDG-merged value via [`Self::with_config`] before entering the
@@ -346,6 +339,18 @@ pub struct App {
     /// after [`INDENT_FLASH_DURATION`] has elapsed. Drained by
     /// [`Self::indent_flash_active`].
     pub(crate) indent_flash: Option<IndentFlash>,
+}
+
+/// Memoised result of [`crate::render::search_count`]. Stored in a
+/// `RefCell` on `App` so the render path (taking `&App`) can refresh
+/// it without restructuring callers.
+#[derive(Debug, Clone)]
+pub(crate) struct SearchCountCache {
+    pub buffer_id: crate::syntax::BufferId,
+    pub dirty_gen: u64,
+    pub cursor: (usize, usize),
+    pub pattern: String,
+    pub result: Option<(usize, usize)>,
 }
 
 /// Tracks how long the mouse has been stationary at a given terminal cell.
@@ -480,25 +485,13 @@ pub(super) fn build_slot(
         let vp = editor.host().viewport();
         (vp.top_row, vp.height as usize)
     };
-    if let Some(out) = syntax.preview_render(buffer_id, editor.buffer(), vp_top, vp_height) {
+    // Sync render for immediate paint on open. recompute_and_install can't
+    // be called here (slot isn't wired into App.slots yet), so go through
+    // the layer directly.
+    let huge = config.editor.huge_file_threshold;
+    if let Some(out) = syntax.render_viewport(buffer_id, editor.buffer(), vp_top, vp_height, huge) {
         editor.install_ratatui_syntax_spans(out.spans);
     }
-    syntax.submit_render(
-        buffer_id,
-        editor.buffer(),
-        vp_top,
-        vp_height,
-        crate::syntax::ParseKind::Viewport,
-    );
-    let initial_dg = editor.buffer().dirty_gen();
-    let (key, signs) = if let Some(out) = syntax.wait_for_initial_result(Duration::from_millis(150))
-    {
-        let k = out.key;
-        editor.install_ratatui_syntax_spans(out.spans);
-        (Some(k), out.signs)
-    } else {
-        (Some((initial_dg, vp_top, vp_height)), Vec::new())
-    };
     let _ = editor.take_content_edits();
     let _ = editor.take_content_reset();
 
@@ -509,25 +502,18 @@ pub(super) fn build_slot(
         dirty: false,
         is_new_file,
         is_untracked: false,
-        diag_signs: signs,
+        diag_signs: Vec::new(),
         diag_signs_lsp: Vec::new(),
         lsp_diags: Vec::new(),
         last_lsp_dirty_gen: None,
         git_signs: Vec::new(),
         last_git_dirty_gen: None,
         last_git_refresh_at: Instant::now(),
-        last_recompute_at: Instant::now() - Duration::from_secs(1),
-        last_recompute_key: key,
         saved_hash: 0,
         saved_len: 0,
         disk_mtime,
         disk_len,
         disk_state: DiskState::Synced,
-        viewport_render_output: None,
-        last_sync_viewport_key: None,
-        installed_spans_dg: None,
-        installed_rows: None,
-        dirty_rows_log: Vec::new(),
     };
     slot.snapshot_saved();
     Ok(slot)
@@ -805,41 +791,9 @@ impl App {
         let edits = self.active_mut().editor.take_content_edits();
         if !edits.is_empty() {
             self.syntax.apply_edits(buffer_id, &edits);
-            // Record which rows were touched by this batch of edits so the
-            // merger can keep untouched cache rows visible while the worker
-            // parses the new content.  The dirty_gen AFTER the edit is the
-            // current one — any cache older than this gen is stale for these
-            // rows and should show blank until the worker returns.
-            let new_dg = self.active().editor.buffer().dirty_gen();
-            // Row-count edits: translate cached span rows in-place so
-            // untouched lines keep their existing colours while the worker
-            // reparses. Historically this branch blanked `buffer_spans`
-            // (visible as a white flash on every Enter / backspace-at-BOL).
-            // We shift BOTH the editor's live `buffer_spans` (drives the
-            // next render frame) AND the per-slot `RenderOutput.spans`
-            // caches (drive `install_merged_spans_for_slot`, which would
-            // otherwise wholesale-reject the stale-length caches and blank
-            // the editor on the very next `recompute_and_install` tick).
             self.active_mut()
                 .editor
                 .shift_syntax_spans_for_edits(&edits);
-            let active_idx = self.focused_slot_idx();
-            self.shift_cached_render_output_spans_for_slot(active_idx, &edits);
-            for edit in &edits {
-                let start_row = edit.start_position.0 as usize;
-                let end_row =
-                    (edit.old_end_position.0 as usize).max(edit.new_end_position.0 as usize);
-                self.active_mut()
-                    .dirty_rows_log
-                    .push((new_dg, start_row..=end_row));
-            }
-            // Cap to 256 entries to avoid unbounded growth.
-            const DIRTY_LOG_CAP: usize = 256;
-            let log = &mut self.active_mut().dirty_rows_log;
-            if log.len() > DIRTY_LOG_CAP {
-                let drain_count = log.len() - DIRTY_LOG_CAP;
-                log.drain(..drain_count);
-            }
         }
         self.lsp_notify_change_active();
         self.recompute_and_install();
@@ -1176,16 +1130,9 @@ impl App {
             theme,
             preview_highlighters: std::sync::Mutex::new(std::collections::HashMap::new()),
             syntax_enabled: true,
+            search_count_cache: std::cell::RefCell::new(None),
             pending_recompute: false,
-            last_recompute_us: 0,
-            last_install_us: 0,
             last_signature_us: 0,
-            last_git_us: 0,
-            last_perf: crate::syntax::PerfBreakdown::default(),
-            recompute_hits: 0,
-            recompute_throttled: 0,
-            recompute_runs: 0,
-            syntax_stale_drops: 0,
             config: hjkl_app::config::Config::default(),
             start_screen,
             lsp: None,

--- a/apps/hjkl/src/app/picker_glue.rs
+++ b/apps/hjkl/src/app/picker_glue.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use crate::picker_action::AppAction;
 
@@ -760,18 +760,10 @@ fn build_scratch_slot(
         let vp = editor.host().viewport();
         (vp.top_row, vp.height as usize)
     };
-    if let Some(out) = syntax.preview_render(buffer_id, editor.buffer(), vp_top, vp_height) {
+    let huge = config.editor.huge_file_threshold;
+    if let Some(out) = syntax.render_viewport(buffer_id, editor.buffer(), vp_top, vp_height, huge) {
         editor.install_ratatui_syntax_spans(out.spans);
     }
-    let initial_dg = editor.buffer().dirty_gen();
-    let (key, signs) = if let Some(out) = syntax.wait_for_initial_result(Duration::from_millis(150))
-    {
-        let k = out.key;
-        editor.install_ratatui_syntax_spans(out.spans);
-        (Some(k), out.signs)
-    } else {
-        (Some((initial_dg, vp_top, vp_height)), Vec::new())
-    };
 
     let mut slot = BufferSlot {
         buffer_id,
@@ -780,25 +772,18 @@ fn build_scratch_slot(
         dirty: false,
         is_new_file: false,
         is_untracked: false,
-        diag_signs: signs,
+        diag_signs: Vec::new(),
         diag_signs_lsp: Vec::new(),
         lsp_diags: Vec::new(),
         last_lsp_dirty_gen: None,
         git_signs: Vec::new(),
         last_git_dirty_gen: None,
         last_git_refresh_at: Instant::now(),
-        last_recompute_at: Instant::now() - Duration::from_secs(1),
-        last_recompute_key: key,
         saved_hash: 0,
         saved_len: 0,
         disk_mtime: None,
         disk_len: None,
         disk_state: DiskState::Synced,
-        viewport_render_output: None,
-        last_sync_viewport_key: None,
-        installed_spans_dg: None,
-        installed_rows: None,
-        dirty_rows_log: Vec::new(),
     };
     slot.snapshot_saved();
     Ok(slot)

--- a/apps/hjkl/src/app/prompt.rs
+++ b/apps/hjkl/src/app/prompt.rs
@@ -730,18 +730,11 @@ impl App {
             git_signs: Vec::new(),
             last_git_dirty_gen: None,
             last_git_refresh_at: Instant::now(),
-            last_recompute_at: Instant::now(),
-            last_recompute_key: None,
             saved_hash: 0,
             saved_len: 0,
             disk_mtime: None,
             disk_len: None,
             disk_state: crate::app::DiskState::Synced,
-            viewport_render_output: None,
-            last_sync_viewport_key: None,
-            installed_spans_dg: None,
-            installed_rows: None,
-            dirty_rows_log: Vec::new(),
         };
         self.slots.push(slot);
         let slot_idx = self.slots.len() - 1;

--- a/apps/hjkl/src/app/syntax_glue.rs
+++ b/apps/hjkl/src/app/syntax_glue.rs
@@ -1,7 +1,6 @@
 use hjkl_engine::{Host, Query};
 use hjkl_engine_tui::EditorRatatuiExt;
 use std::path::Path;
-use std::time::{Duration, Instant};
 
 use hjkl_bonsai::{CommentMarkerPass, Highlighter, Theme};
 use hjkl_engine::types::{Attrs, Color as EngineColor, Style as EngineStyle};
@@ -33,22 +32,18 @@ fn change_to_sign(c: GitChange) -> Sign {
 
 impl App {
     /// Queue a git diff-sign refresh for the current buffer (throttled).
-    /// Non-blocking: submits a job to the background worker.
     pub(crate) fn refresh_git_signs(&mut self) {
         self.refresh_git_signs_inner(false);
     }
 
     /// Queue a git diff-sign refresh for the current buffer, bypassing
-    /// the 250 ms throttle. The result still arrives asynchronously.
+    /// the 250 ms throttle.
     pub(crate) fn refresh_git_signs_force(&mut self) {
         self.refresh_git_signs_inner(true);
     }
 
-    /// Shared submission logic.
-    ///
-    /// Checks dirty_gen + throttle, then snapshots buffer content and
-    /// submits a [`GitJob`] to the background worker. Returns immediately.
     pub(crate) fn refresh_git_signs_inner(&mut self, force: bool) {
+        use std::time::{Duration, Instant};
         const REFRESH_MIN_INTERVAL: Duration = Duration::from_millis(250);
         let huge_file_lines = self.config.editor.huge_file_threshold;
 
@@ -73,10 +68,6 @@ impl App {
             return;
         }
 
-        // Reuse the per-dirty_gen cached `Arc<String>` so this doesn't
-        // re-clone every row per keystroke (paired with the same call
-        // in `lsp_notify_change_active` + `buffer_signature` + the
-        // syntax submit path — all share one allocation per generation).
         let text = self.active().editor.buffer().content_joined();
         let mut bytes = text.as_bytes().to_vec();
         if !bytes.is_empty() {
@@ -93,39 +84,28 @@ impl App {
         });
     }
 
-    /// Drain completed git-sign results from the worker and install them
-    /// onto their target slots. Called once per event-loop tick.
-    ///
-    /// Returns `true` when at least one result was installed and a redraw
-    /// is needed.
+    /// Drain completed git-sign results from the worker and install them.
     pub(crate) fn poll_git_signs(&mut self) -> bool {
         let mut redraw = false;
         while let Some(result) = self.git_worker.try_recv() {
-            // Find the slot with this buffer_id (may have been deleted; drop).
             if let Some(slot) = self
                 .slots
                 .iter_mut()
                 .find(|s| s.buffer_id == result.buffer_id)
-            {
-                // Stale check: only install if no newer dirty_gen has overtaken.
-                if slot
+                && slot
                     .last_git_dirty_gen
                     .is_none_or(|dg| dg <= result.dirty_gen)
-                {
-                    slot.git_signs = result.changes.into_iter().map(change_to_sign).collect();
-                    slot.is_untracked = result.is_untracked;
-                    slot.last_git_dirty_gen = Some(result.dirty_gen);
-                    redraw = true;
-                }
+            {
+                slot.git_signs = result.changes.into_iter().map(change_to_sign).collect();
+                slot.is_untracked = result.is_untracked;
+                slot.last_git_dirty_gen = Some(result.dirty_gen);
+                redraw = true;
             }
         }
         redraw
     }
 
-    /// Poll in-flight async grammar loads and wire any that completed into
-    /// the syntax layer.  Called each tick alongside `try_recv_latest` so
-    /// freshly-compiled grammars activate without waiting for the next
-    /// file-open event.
+    /// Poll in-flight async grammar loads and wire any that completed.
     ///
     /// Returns `true` when at least one load resolved and a redraw is needed.
     pub(crate) fn poll_grammar_loads(&mut self) -> bool {
@@ -133,17 +113,16 @@ impl App {
         if events.is_empty() {
             return false;
         }
-        let active_id = self.active().buffer_id;
         for event in &events {
             use crate::syntax::LoadEventKind;
             hjkl_syntax::SyntaxLayer::dispatch_load_event(event, |kind| match kind {
                 LoadEventKind::Ready { id, name } => {
                     tracing::debug!("grammar load complete: {name} (buffer {id})");
-                    // If the completed load is for the active buffer, clear
-                    // the recompute cache key so the next recompute_and_install
-                    // submits a fresh parse with the new language.
-                    if id == active_id {
-                        self.active_mut().last_recompute_key = None;
+                    // Re-attach the grammar now that it's ready.
+                    if let Some(slot) = self.slots.iter().find(|s| s.buffer_id == id)
+                        && let Some(ref p) = slot.filename.clone()
+                    {
+                        let _ = self.syntax.set_language_for_path(id, p);
                     }
                 }
                 LoadEventKind::Failed { id, name, error } => {
@@ -155,10 +134,7 @@ impl App {
         true
     }
 
-    /// Poll in-flight anvil install handles each tick and fan status events
-    /// into the notification bus and `anvil_log`.
-    ///
-    /// Returns `true` when at least one event arrived and a redraw is useful.
+    /// Poll in-flight anvil install handles each tick.
     pub(crate) fn poll_anvil_jobs(&mut self) -> bool {
         use hjkl_anvil::InstallStatus;
 
@@ -205,12 +181,11 @@ impl App {
                     InstallStatus::Installing => {
                         self.bus.info(format!("anvil: {name} installing"));
                     }
-                    InstallStatus::Queued => {
-                        // No toast for the queued state — it's transient.
-                    }
-                    InstallStatus::TofuRecorded { triple, .. } => {
+                    InstallStatus::Queued => {}
+                    InstallStatus::TofuRecorded { triple, sha256 } => {
                         self.bus
                             .info(format!("anvil: {name} TOFU hash recorded for {triple}"));
+                        let _ = sha256;
                     }
                 }
             }
@@ -223,832 +198,75 @@ impl App {
         redraw
     }
 
-    /// Install a worker-produced `RenderOutput` onto the slot whose
-    /// `buffer_id` matches `out.buffer_id`.
-    ///
-    /// Routes into the correct per-slot cache field by `out.kind`:
-    /// - `Viewport` → `viewport_render_output`
-    /// - `Top`      → `top_render_output`
-    /// - `Bottom`   → `bottom_render_output`
-    ///
-    /// After updating the cache, merges all three caches and installs the
-    /// union onto the editor (for the active buffer) or stores for later
-    /// (for non-active buffers, so `switch_to` can restore spans without
-    /// waiting for a fresh parse).
-    ///
-    /// Returns `true` if the live install ran on the active buffer, `false`
-    /// for non-active routes and genuine stale drops (no matching slot).
-    pub(crate) fn install_render_result(&mut self, out: crate::syntax::RenderOutput) -> bool {
-        let active_id = self.active().buffer_id;
-
-        // Find the slot that owns this buffer_id.
-        let Some(slot_idx) = self.slots.iter().position(|s| s.buffer_id == out.buffer_id) else {
-            // No slot matched (buffer was closed before the result arrived).
-            self.syntax_stale_drops = self.syntax_stale_drops.saturating_add(1);
-            return false;
-        };
-
-        let is_active = out.buffer_id == active_id;
-
-        // Plan-B (#233): the worker now ships EMPTY span tables — it
-        // only refreshes the shared retained tree.
-        //
-        // For `Viewport` kind: the empty signal is discarded.
-        // `recompute_and_install` already runs a sync `query_viewport`
-        // against the fresh tree at the end of every tick, so firing
-        // an extra sync here only duplicates work (the signal's range
-        // is the async submit's over-provisioned span, not the visible
-        // viewport — different dedup key, so it wouldn't short-circuit).
-        //
-        // For `Top` / `Bottom`: the recompute path no longer runs sync
-        // for these kinds on every tick (typing was 1Hz because each
-        // keystroke re-highlighted ~240 prewarm rows with full CSS
-        // injection reparse). Instead, trigger sync here when the
-        // async worker delivers a fresh tree for that prewarm region.
-        // The buffer's current dirty_gen is used so the sync result
-        // is tagged correctly even if the worker's parse was for an
-        // older gen — the dedup + generation guard handle the rest.
-        if out.spans.is_empty() {
-            if !is_active {
-                return false;
-            }
-            match out.kind {
-                crate::syntax::ParseKind::Viewport => {
-                    // Worker just refreshed the retained tree. The sync
-                    // query that ran during the keystroke was deferred
-                    // (tree was dirty); now the tree is fresh, refresh
-                    // the install cache.
-                    //
-                    // Use the `changed_ranges` tree-sitter reports
-                    // between the pre-edit tree and the post-parse tree
-                    // to walk only the row regions that actually
-                    // changed — typically one row for single-char
-                    // typing, vs a full ~25ms viewport walk. Rows
-                    // outside `changed_ranges` keep their existing
-                    // installed spans (tree-sitter says they didn't
-                    // change so they're still correct).
-                    self.slots[slot_idx].last_sync_viewport_key = None;
-                    let buf_dg = self.slots[slot_idx].editor.buffer().dirty_gen();
-                    let (vp_top, vp_height) = {
-                        let vp = self.active().editor.host().viewport();
-                        (vp.top_row, vp.height as usize)
-                    };
-                    let vp_byte_to_row = |bytes: &[usize], byte: usize| {
-                        bytes.partition_point(|&b| b <= byte).saturating_sub(1)
-                    };
-                    if out.changed_ranges.is_empty() {
-                        // Cold parse or no structural change → full
-                        // viewport refresh. Clear the per-row cache so
-                        // the sync_query_region walk fires.
-                        self.slots[slot_idx].installed_spans_dg = None;
-                        self.slots[slot_idx].installed_rows = None;
-                        self.sync_query_region(out.buffer_id, vp_top, vp_height, buf_dg, out.kind);
-                    } else if let Some((_, row_starts, _, cache_dg)) =
-                        self.syntax.cached_source(out.buffer_id)
-                        && cache_dg == buf_dg
-                    {
-                        // Compute the total row footprint of all
-                        // changed_ranges, capped at 2x viewport. Above
-                        // that cap (e.g. undo of a huge paste where
-                        // tree-sitter reports `[3..991925]`) we'd
-                        // freeze the UI for seconds walking each
-                        // changed row synchronously. Fall back to a
-                        // viewport-only walk + drop the per-row cache
-                        // for off-viewport rows (they'll be walked on
-                        // demand when the user scrolls there).
-                        let row_starts = row_starts.as_ref();
-                        let prior_installed = self.slots[slot_idx].installed_rows.clone();
-                        let row_spans: Vec<(usize, usize)> = out
-                            .changed_ranges
-                            .iter()
-                            .map(|r| {
-                                let row_start = vp_byte_to_row(row_starts, r.start);
-                                let row_end =
-                                    vp_byte_to_row(row_starts, r.end.saturating_sub(1)) + 1;
-                                (row_start, row_end)
-                            })
-                            .collect();
-                        let total_changed_rows: usize =
-                            row_spans.iter().map(|(s, e)| e.saturating_sub(*s)).sum();
-                        let huge = total_changed_rows > vp_height.saturating_mul(2);
-                        tracing::debug!(
-                            target: "hjkl::profile",
-                            ranges = ?out.changed_ranges,
-                            prior = ?prior_installed,
-                            vp_top, vp_height,
-                            total_changed_rows,
-                            huge,
-                            "changed_ranges raw"
-                        );
-                        if huge {
-                            // Drop the cache; sync_query_region will
-                            // walk just the visible viewport, and
-                            // off-viewport rows will be walked lazily.
-                            self.slots[slot_idx].installed_spans_dg = None;
-                            self.slots[slot_idx].installed_rows = None;
-                            self.sync_query_region(
-                                out.buffer_id,
-                                vp_top,
-                                vp_height,
-                                buf_dg,
-                                out.kind,
-                            );
-                            return true;
-                        }
-                        for (row_start, row_end) in row_spans {
-                            let (clamp_start, clamp_end) = match &prior_installed {
-                                Some(r) => (r.start, r.end),
-                                None => (vp_top, vp_top + vp_height),
-                            };
-                            let row_start = row_start.max(clamp_start);
-                            let row_end = row_end.min(clamp_end);
-                            if row_start >= row_end {
-                                continue;
-                            }
-                            let _ = self.sync_query_changed_rows(
-                                out.buffer_id,
-                                slot_idx,
-                                row_start,
-                                row_end - row_start,
-                                buf_dg,
-                            );
-                        }
-                        // Shrink installed_rows to JUST the viewport.
-                        // We only re-walked the changed regions inside
-                        // the prior installed range; rows that were in
-                        // the prior installed range but OUTSIDE both
-                        // the viewport AND the changed_ranges still
-                        // hold pre-undo spans (which may be stale or
-                        // empty after the buffer shrank). Letting the
-                        // row-cache claim coverage for those would
-                        // paint stale / blank rows when the user
-                        // scrolls there. Shrinking forces a row-cache
-                        // miss → delta walk on demand for off-viewport
-                        // rows, refreshing them against the
-                        // post-undo tree.
-                        self.slots[slot_idx].installed_spans_dg = Some(buf_dg);
-                        self.slots[slot_idx].installed_rows = Some(vp_top..(vp_top + vp_height));
-                        self.slots[slot_idx].last_sync_viewport_key = None;
-                    } else {
-                        // Source cache stale — fall back to full refresh.
-                        self.slots[slot_idx].installed_spans_dg = None;
-                        self.slots[slot_idx].installed_rows = None;
-                        self.sync_query_region(out.buffer_id, vp_top, vp_height, buf_dg, out.kind);
-                    }
-                    return true;
-                }
-                _ => return false,
-            }
-        }
-
-        // Generation-aware install: a render result tagged with an older
-        // `dirty_gen` than what's already cached (or older than the
-        // buffer's current dirty_gen) is from a parse that was in flight
-        // when newer state landed — installing it would clobber the
-        // fresher sync `query_viewport` cache. Drop it.
-        //
-        // Symptoms when this guard is missing:
-        // - undo/redo of a multi-line edit: worker reparse for the
-        //   pre-undo source arrives after the sync query installed the
-        //   post-undo spans → editor paints with pre-undo colours that
-        //   don't match the visible text until the NEXT submit lands.
-        // - rapid typing: each keystroke ticks dirty_gen; worker results
-        //   are always one or two gens behind sync results.
-        let buf_dg = self.slots[slot_idx].editor.buffer().dirty_gen();
-        let out_dg = out.key.0;
-        if out_dg < buf_dg {
-            self.syntax_stale_drops = self.syntax_stale_drops.saturating_add(1);
-            return false;
-        }
-        let existing_dg = match out.kind {
-            crate::syntax::ParseKind::Viewport => self.slots[slot_idx]
-                .viewport_render_output
-                .as_ref()
-                .map(|o| o.key.0),
-            // Unknown future kind: treat as install (conservative).
-            _ => None,
-        };
-        if let Some(existing) = existing_dg
-            && out_dg < existing
-        {
-            self.syntax_stale_drops = self.syntax_stale_drops.saturating_add(1);
-            return false;
-        }
-
-        // Route into the correct per-slot cache field via the exhaustive dispatch
-        // helper so no wildcard arm is needed despite ParseKind being #[non_exhaustive].
-        use crate::syntax::ParseKindKind;
-        hjkl_syntax::SyntaxLayer::dispatch_parse_kind(out.kind, |kind| match kind {
-            ParseKindKind::Viewport => {
-                // Install diag signs from viewport results (only kind that
-                // runs the diagnostic scan over the visible region).
-                if is_active {
-                    let signs = out.signs.clone();
-                    let active_idx = self.focused_slot_idx();
-                    self.slots[active_idx].diag_signs = signs;
-                }
-                self.slots[slot_idx].viewport_render_output = Some(out.clone());
-            }
-        });
-
-        if is_active {
-            // Active buffer: patch ONLY the result's range on the editor
-            // instead of re-running the merger over `line_count`. This
-            // keeps per-keystroke install cost proportional to viewport
-            // height (~80 rows) rather than file size — without it j/k
-            // on a 10k-row file shows visible cursor lag because the
-            // merger + full ratatui install touch every row.
-            //
-            // Cross-region rows (e.g. Top + Viewport overlap when the
-            // cursor is near the top) auto-resolve: the most recently
-            // installed kind wins. Because Viewport is the kind that
-            // moves on every j/k, "newest = correct viewport" naturally
-            // holds.
-            use hjkl_engine_tui::EditorRatatuiExt;
-            let range_top = out.key.1;
-            let range_height = out.key.2;
-            let active_idx = self.focused_slot_idx();
-            let line_count = self.slots[active_idx].editor.buffer().line_count() as usize;
-            let end = (range_top + range_height)
-                .min(line_count)
-                .min(out.spans.len());
-            let start = range_top.min(end);
-            let slice = &out.spans[start..end];
-            self.slots[active_idx]
-                .editor
-                .patch_ratatui_syntax_spans_range(start..end, slice);
-            return true;
-        }
-        // Non-active buffer: cached above, live install deferred to switch_to.
-        false
-    }
-
-    /// Walk + install spans for a specific row range, bypassing the
-    /// per-row install cache. Used by the changed-ranges refresh path
-    /// in `install_render_result`: after the worker delivers, walk
-    /// only the rows tree-sitter reports as structurally changed
-    /// rather than re-walking the full viewport.
-    fn sync_query_changed_rows(
-        &mut self,
-        buffer_id: crate::syntax::BufferId,
-        slot_idx: usize,
-        row_top: usize,
-        row_height: usize,
-        current_dg: u64,
-    ) -> bool {
-        let _ = slot_idx;
-        let Some((source, row_starts, line_count_arc, cache_dg)) =
-            self.syntax.cached_source(buffer_id)
-        else {
-            return false;
-        };
-        if cache_dg != current_dg {
-            return false;
-        }
-        let bytes_len = source.len();
-        let byte_start = row_starts.get(row_top).copied().unwrap_or(bytes_len);
-        let end_row = row_top + row_height + 1;
-        let byte_end = row_starts
-            .get(end_row)
-            .copied()
-            .unwrap_or(bytes_len)
-            .min(bytes_len)
-            .max(byte_start);
-        let t_q = Instant::now();
-        let sync_out = self.syntax.query_viewport(
-            buffer_id,
-            source.as_str(),
-            row_starts.as_ref(),
-            byte_start..byte_end,
-            row_top,
-            row_height,
-            line_count_arc,
-            current_dg,
-            crate::syntax::ParseKind::Viewport,
-        );
-        let q_us = t_q.elapsed().as_micros();
-        let installed = if let Some(sync_out) = sync_out {
-            self.install_render_result(sync_out);
-            true
-        } else {
-            false
-        };
-        tracing::debug!(
-            target: "hjkl::profile",
-            row_top, row_height,
-            byte_len = byte_end - byte_start,
-            q_us,
-            installed,
-            "sync_query changed-rows"
-        );
-        installed
-    }
-
-    /// Run a sync `query_viewport` against the active buffer's retained
-    /// tree for an arbitrary `(top, height)` region and install the
-    /// result. Skips silently when the cached source is stale (throttled
-    /// submit hasn't fired the cache rebuild yet) or when no retained
-    /// tree exists. Generic over `ParseKind` so Viewport / Top / Bottom
-    /// all use the same code path.
-    ///
-    /// `current_dg` is the buffer's current dirty_gen — used both to
-    /// detect cache staleness and to tag the resulting `RenderOutput`
-    /// so the install path's generation guard knows this result is fresh.
-    fn sync_query_region(
-        &mut self,
-        buffer_id: crate::syntax::BufferId,
-        range_top: usize,
-        range_height: usize,
-        current_dg: u64,
-        kind: crate::syntax::ParseKind,
-    ) -> bool {
-        // Per-tick dedup: skip the highlight + merge + install pipeline
-        // when nothing changed since the previous run for this
-        // `(buffer, kind)`. Without this gate `recompute_and_install`
-        // re-walks the whole `line_count` x 3-cache merger every event
-        // loop iteration, which scrolls a large file feels visibly
-        // laggy at idle.
-        let Some(slot_idx) = self.slots.iter().position(|s| s.buffer_id == buffer_id) else {
-            return false;
-        };
-        let new_key = (current_dg, range_top, range_height);
-        let last_key = match kind {
-            crate::syntax::ParseKind::Viewport => self.slots[slot_idx].last_sync_viewport_key,
-            _ => None,
-        };
-        if last_key == Some(new_key) {
-            tracing::debug!(target: "hjkl::profile", ?kind, range_top, range_height, current_dg, "sync_query dedup-hit");
-            return true;
-        }
-
-        // Per-row install cache: when the new viewport's row range is
-        // already fully covered by previously-installed rows for the
-        // current dirty_gen, skip the walk entirely (j/k within an
-        // already-walked region is free). Otherwise walk only the
-        // *delta* rows — the parts of the new viewport that aren't yet
-        // installed. Scroll-by-one then costs one row's worth of
-        // tree-sitter walk, not a full 55-row viewport walk.
-        let vp_range = range_top..(range_top + range_height);
-        let cached_dg_opt = self.slots[slot_idx].installed_spans_dg;
-        let cached_for_dg =
-            matches!(kind, crate::syntax::ParseKind::Viewport) && cached_dg_opt == Some(current_dg);
-
-        // Typing path: dg bumped since last walk AND we have a prior
-        // install. Tree was just edited (tree.edit synced) but the
-        // worker reparse is in flight. Walking the dirty tree here
-        // would block the key handler ~30-50ms per char and return
-        // partial results. Instead, leave the row-shifted installed
-        // spans visible for one frame; worker delivery will trigger
-        // `install_render_result`'s Viewport branch, which re-runs
-        // this method against the freshly-parsed tree.
-        if matches!(kind, crate::syntax::ParseKind::Viewport)
-            && cached_dg_opt.is_some()
-            && cached_dg_opt != Some(current_dg)
-        {
-            tracing::debug!(
-                target: "hjkl::profile",
-                cached_dg = ?cached_dg_opt,
-                current_dg,
-                "sync_query defer (tree dirty)"
-            );
-            // Update dedup so we don't keep re-checking the same key.
-            self.slots[slot_idx].last_sync_viewport_key = Some(new_key);
-            return true;
-        }
-
-        let cached_rows = if cached_for_dg {
-            self.slots[slot_idx].installed_rows.clone()
-        } else {
-            None
-        };
-        let walk_ranges: Vec<std::ops::Range<usize>> = match cached_rows.as_ref() {
-            Some(installed)
-                if installed.start <= vp_range.start && installed.end >= vp_range.end =>
-            {
-                // Fully covered — no walk needed. Update dedup key so
-                // subsequent identical calls also short-circuit.
-                tracing::debug!(
-                    target: "hjkl::profile",
-                    ?kind, range_top, range_height, current_dg,
-                    installed_start = installed.start, installed_end = installed.end,
-                    "sync_query row-cache hit"
-                );
-                if let crate::syntax::ParseKind::Viewport = kind {
-                    self.slots[slot_idx].last_sync_viewport_key = Some(new_key);
-                }
-                return true;
-            }
-            Some(installed) => {
-                let mut deltas = Vec::with_capacity(2);
-                if vp_range.start < installed.start {
-                    deltas.push(vp_range.start..installed.start.min(vp_range.end));
-                }
-                if vp_range.end > installed.end {
-                    deltas.push(installed.end.max(vp_range.start)..vp_range.end);
-                }
-                deltas
-            }
-            None => vec![vp_range.clone()],
-        };
-
-        let t_sync = Instant::now();
-        let Some((source, row_starts, line_count_arc, cache_dg)) =
-            self.syntax.cached_source(buffer_id)
-        else {
-            return false;
-        };
-        if cache_dg != current_dg {
-            return false;
-        }
-        let bytes_len = source.len();
-
-        let mut installed_any = false;
-        let mut total_q_us: u128 = 0;
-        let mut total_install_us: u128 = 0;
-        let mut total_byte_len: usize = 0;
-        for delta in &walk_ranges {
-            if delta.start >= delta.end {
-                continue;
-            }
-            let d_byte_start = row_starts.get(delta.start).copied().unwrap_or(bytes_len);
-            let d_end_row = delta.end + 1;
-            let d_byte_end = row_starts
-                .get(d_end_row)
-                .copied()
-                .unwrap_or(bytes_len)
-                .min(bytes_len)
-                .max(d_byte_start);
-            total_byte_len += d_byte_end - d_byte_start;
-            let t_q = Instant::now();
-            let sync_out = self.syntax.query_viewport(
-                buffer_id,
-                source.as_str(),
-                row_starts.as_ref(),
-                d_byte_start..d_byte_end,
-                delta.start,
-                delta.end - delta.start,
-                line_count_arc,
-                current_dg,
-                kind,
-            );
-            total_q_us += t_q.elapsed().as_micros();
-            if let Some(sync_out) = sync_out {
-                let t_install = Instant::now();
-                self.install_render_result(sync_out);
-                total_install_us += t_install.elapsed().as_micros();
-                installed_any = true;
-            }
-        }
-
-        if !installed_any {
-            return false;
-        }
-
-        tracing::debug!(
-            target: "hjkl::profile",
-            ?kind, range_top, range_height,
-            byte_len = total_byte_len,
-            delta_count = walk_ranges.len(),
-            q_us = total_q_us,
-            install_us = total_install_us,
-            total_us = t_sync.elapsed().as_micros(),
-            "sync_query miss"
-        );
-
-        if let crate::syntax::ParseKind::Viewport = kind {
-            self.slots[slot_idx].last_sync_viewport_key = Some(new_key);
-            // Extend the per-row install cache to cover the full viewport
-            // (existing installed range ∪ new vp range). Single-range
-            // representation keeps the membership check O(1).
-            let new_installed = match cached_rows {
-                Some(existing) => {
-                    existing.start.min(vp_range.start)..existing.end.max(vp_range.end)
-                }
-                None => vp_range,
-            };
-            self.slots[slot_idx].installed_spans_dg = Some(current_dg);
-            self.slots[slot_idx].installed_rows = Some(new_installed);
-        }
-        true
-    }
-
-    /// Run sync `query_viewport` for the active buffer's Viewport region
-    /// (the over-provisioned visible window). On cold-open / post-reset
-    /// where no retained tree exists, falls back to the one-shot
-    /// `preview_render` so the visible rows paint immediately.
-    fn sync_query_active_viewport(
-        &mut self,
-        buffer_id: crate::syntax::BufferId,
-        oversize_top: usize,
-        oversize_height: usize,
-        fallback_top: usize,
-        fallback_height: usize,
-        current_dg: u64,
-    ) {
-        let installed = self.sync_query_region(
-            buffer_id,
-            oversize_top,
-            oversize_height,
-            current_dg,
-            crate::syntax::ParseKind::Viewport,
-        );
-        if installed {
-            return;
-        }
-        // No retained tree (cold open / post-reset). Fall back to the
-        // one-shot `preview_render` so the visible rows paint immediately
-        // instead of waiting on the async worker.
-        let active_idx = self.focused_slot_idx();
-        let buf = self.slots[active_idx].editor.buffer();
-        if let Some(preview) =
-            self.syntax
-                .preview_render(buffer_id, buf, fallback_top, fallback_height)
-        {
-            self.install_render_result(preview);
-        }
-    }
-
-    /// Handle a `take_content_reset` event on the active buffer: clear the
-    /// per-slot `RenderOutput` caches (their row counts no longer match
-    /// the post-replace buffer), blank the editor's installed
-    /// `buffer_spans`, and tell the syntax layer to drop the shared
-    /// retained tree synchronously so the next `query_viewport` returns
-    /// `None` and falls back to the one-shot `preview_render`.
-    ///
-    /// Called from every site that drains `take_content_reset` — kept
-    /// here so the multi-step bookkeeping cannot drift between call
-    /// sites (4 in `event_loop.rs`, 1 in `sync_after_engine_mutation`).
+    /// Handle a `take_content_reset` event on the active buffer.
     pub(crate) fn handle_active_content_reset(&mut self, buffer_id: crate::syntax::BufferId) {
         self.syntax.reset(buffer_id);
         let active_idx = self.focused_slot_idx();
-        let slot = &mut self.slots[active_idx];
-        slot.viewport_render_output = None;
-        // Clear sync dedup key so the post-reset sync query is not
-        // skipped if the new dirty_gen + viewport happen to match a
-        // pre-reset key.
-        slot.last_sync_viewport_key = None;
-        slot.installed_spans_dg = None;
-        slot.installed_rows = None;
-        slot.editor.install_ratatui_syntax_spans(Vec::new());
+        self.slots[active_idx]
+            .editor
+            .install_ratatui_syntax_spans(Vec::new());
     }
 
-    /// Translate the per-slot cached `RenderOutput.spans` row vectors
-    /// in-place to track a batch of [`hjkl_engine::ContentEdit`]s, mirroring
-    /// what [`hjkl_engine::Editor::shift_syntax_spans_for_edits`] does for
-    /// the live `buffer_spans`.
-    ///
-    /// Shifting the viewport cache keeps it shape-compatible with the new
-    /// line count: rows touched by the edit stay blank for one frame
-    /// (worker fills them in), untouched rows keep their cached colours.
-    pub(crate) fn shift_cached_render_output_spans_for_slot(
-        &mut self,
-        slot_idx: usize,
-        edits: &[hjkl_engine::ContentEdit],
-    ) {
-        if edits.is_empty() {
-            return;
-        }
-        let slot = &mut self.slots[slot_idx];
-        if let Some(out) = slot.viewport_render_output.as_mut() {
-            shift_rows(&mut out.spans, edits);
-        }
-    }
-
-    /// Submit a new viewport-scoped parse on the syntax worker and install
-    /// whatever the worker has produced since the last frame.
+    /// Run `render_viewport` for the active buffer and install the result.
+    /// Returns empty spans when no grammar is attached, grammar is loading,
+    /// or the buffer exceeds `huge_file_threshold`.
     pub(crate) fn recompute_and_install(&mut self) {
         if !self.syntax_enabled {
             return;
         }
-        const RECOMPUTE_THROTTLE: Duration = Duration::from_millis(100);
         let buffer_id = self.active().buffer_id;
-        let (focused_top, focused_height) = {
-            let vp = self.active().editor.host().viewport();
-            (vp.top_row, vp.height as usize)
-        };
-
-        // Compute the union viewport across all windows that show the same
-        // slot as the focused window.  This ensures syntax spans are
-        // populated for every visible row, not just the focused window's
-        // rows.  Without the union, switching focus between two windows on
-        // the same buffer leaves one window with un-highlighted rows.
-        let active_slot = self.focused_slot_idx();
-        let mut union_top = focused_top;
-        let mut union_bot = focused_top + focused_height;
-        for w in self.windows.iter().flatten() {
-            if w.slot == active_slot
-                && let Some(rect) = w.last_rect
-            {
-                union_top = union_top.min(w.top_row);
-                union_bot = union_bot.max(w.top_row + rect.h as usize);
-            }
-        }
-        let top = union_top;
-        let height = union_bot - union_top;
-
-        // Worker requests carry only the visible viewport now. The 3x
-        // over-provisioned range was a pre-cache hint for the (now-gone)
-        // parent-spans cache; without it the request range only affects
-        // the result's `key` tag and the worker still parses the full
-        // source either way.
-        let dg = self.active().editor.buffer().dirty_gen();
-        let key = (dg, top, height);
-
-        let prev_dirty_gen = self
-            .active()
-            .last_recompute_key
-            .map(|(prev_dg, _, _)| prev_dg);
-
-        let t_total = Instant::now();
-        let mut submitted = false;
-        if self.active().last_recompute_key == Some(key) {
-            self.recompute_hits = self.recompute_hits.saturating_add(1);
-        } else {
-            let buffer_changed = self
-                .active()
-                .last_recompute_key
-                .map(|(prev_dg, _, _)| prev_dg != dg)
-                .unwrap_or(true);
-            let now = Instant::now();
-            if buffer_changed
-                && now.duration_since(self.active().last_recompute_at) < RECOMPUTE_THROTTLE
-            {
-                self.recompute_throttled = self.recompute_throttled.saturating_add(1);
-            } else {
-                self.recompute_runs = self.recompute_runs.saturating_add(1);
-                // Split borrow: get a raw pointer to the buffer so `self.syntax`
-                // can be borrowed mutably without fighting the borrow checker on
-                // `self.slots`. Safety: the buffer lives inside `self.slots[active]`
-                // which is not touched inside `submit_render`.
-                let submit_result = {
-                    let active_idx = self.focused_slot_idx();
-                    let buf = self.slots[active_idx].editor.buffer();
-                    self.syntax.submit_render(
-                        buffer_id,
-                        buf,
-                        top,
-                        height,
-                        crate::syntax::ParseKind::Viewport,
-                    )
-                };
-                if submit_result.is_some() {
-                    submitted = true;
-                    self.active_mut().last_recompute_at = Instant::now();
-                    self.active_mut().last_recompute_key = Some(key);
-                }
-            }
-        }
-
-        // Plan B (#233): run a sync `query_viewport` against the retained
-        // tree (which already has this frame's `tree.edit` deltas applied
-        // via `SyntaxLayer::apply_edits`) every tick — NOT only when a
-        // submit fired. Pure-scroll ticks (no edit) take the cache-hit /
-        // throttle branch above and skip the submit; without this call
-        // the viewport keeps painting last frame's spans until the
-        // async worker delivers.
-        //
-        // Cheap: ~100µs on warm tree for an 80-row window. The sync
-        // result is tagged with the buffer's current dirty_gen so the
-        // generation guard in `install_render_result` will favour it
-        // over any older worker result still in flight.
-        //
-        // Use the VISIBLE viewport (not the 3x over-provisioned range
-        // the async worker submits) for sync. Over-provisioning helped
-        // the worker pre-cache ahead-of-scroll rows; the sync path
-        // doesn't cache, it just re-queries every tick, so highlighting
-        // 240 rows when only 80 are visible is wasted CPU per j/k.
-        self.sync_query_active_viewport(buffer_id, top, height, top, height, dg);
-
-        // Top / Bottom span-cache prewarms were removed alongside the
-        // parent-spans cache (bonsai refactor). With the tree-as-only-cache
-        // model, `gg` / `G` reparse the viewport against the retained tree
-        // synchronously (~1ms walk on a warm tree). No per-slot Top/Bottom
-        // submits are needed.
-
-        // Pre-warm the retained tree for non-active slots so a buffer
-        // switch finds a warm tree (avoids cold-parse latency on switch).
-        // We submit only Viewport; the worker dedups per (buffer, kind)
-        // so this stays a single in-flight parse per other slot.
-        let active_idx = self.focused_slot_idx();
-        let slot_indices: Vec<usize> = (0..self.slots.len()).filter(|&i| i != active_idx).collect();
-        for slot_idx in slot_indices {
-            let slot_buf_id = self.slots[slot_idx].buffer_id;
-            let (slot_top, slot_height) = {
-                let vp = self.slots[slot_idx].editor.host().viewport();
+        let (top, height) = {
+            // Compute union viewport across all windows showing the same slot.
+            let focused_slot = self.focused_slot_idx();
+            let (focused_top, focused_height) = {
+                let vp = self.active().editor.host().viewport();
                 (vp.top_row, vp.height as usize)
             };
-            let buf = self.slots[slot_idx].editor.buffer();
-            self.syntax.submit_render(
-                slot_buf_id,
-                buf,
-                slot_top,
-                slot_height,
-                crate::syntax::ParseKind::Viewport,
-            );
-        }
-
-        // Detect a "big jump" (viewport teleport past the over-provisioned
-        // band — typically `gg` / `G` / `<C-d>` / `<C-u>` / line-number `:N`).
-        // Without this, the new viewport lands on un-highlighted rows because
-        // the pre-warm cache only covers the previous viewport ±1×.
-        //
-        // Wait budget scales with whether the worker has a retained tree for
-        // this buffer (warm) or not (cold). Warm parses on retained trees
-        // are ~1-5ms; cold initial parses on big files can take hundreds.
-        // Without the cold budget the first `gg`/`G` after open flashes
-        // un-highlighted rows because the 40 ms warm cap times out before
-        // the initial parse completes.
-        //
-        // With the top/bottom caches populated, `gg` / `G` on warm buffers
-        // hit the cache and never flash — the wait here is still useful for
-        // the very first `G` on a cold file before the bottom parse has fired.
-        const WARM_JUMP_WAIT: Duration = Duration::from_millis(40);
-        const COLD_JUMP_WAIT: Duration = Duration::from_millis(500);
-        let is_big_jump = match self.active().last_recompute_key {
-            None => true,
-            Some((_, prev_top, _)) => hjkl_buffer::is_big_viewport_jump(prev_top, top, height),
-        };
-        // Cold = the worker hasn't produced its first tree for this
-        // buffer yet. With Top/Bottom span-cache prewarms gone, the
-        // only "has the worker walked something" signal we have is
-        // `viewport_render_output`. Its absence means the sync walk
-        // would return empty (no retained tree yet) → block longer
-        // on the first `gg`/`G` after open so the destination paints
-        // with spans instead of flashing un-highlighted.
-        let is_cold = self.active().viewport_render_output.is_none();
-        let big_jump_wait = if is_cold {
-            COLD_JUMP_WAIT
-        } else {
-            WARM_JUMP_WAIT
-        };
-        let _ = prev_dirty_gen;
-
-        let t_install = Instant::now();
-        // For big jumps, block briefly on the FIRST result (which is the
-        // active buffer's parse — it was submitted first into the FIFO
-        // queue) then drain everything else. `wait_all_results` returns
-        // every per-buffer result so pre-warm hits also reach their caches.
-        let all_results = if is_big_jump && submitted {
-            self.syntax.wait_all_results(big_jump_wait)
-        } else {
-            self.syntax.take_all_results()
-        };
-        let mut active_installed = false;
-        for out in all_results {
-            if self.install_render_result(out) {
-                active_installed = true;
+            let mut union_top = focused_top;
+            let mut union_bot = focused_top + focused_height;
+            for w in self.windows.iter().flatten() {
+                if w.slot == focused_slot
+                    && let Some(rect) = w.last_rect
+                {
+                    union_top = union_top.min(w.top_row);
+                    union_bot = union_bot.max(w.top_row + rect.h as usize);
+                }
             }
-        }
-        self.last_install_us = if active_installed {
-            t_install.elapsed().as_micros()
-        } else {
-            0
+            (union_top, union_bot - union_top)
         };
-        self.last_perf = self.syntax.last_perf;
 
-        let t_git = Instant::now();
+        let huge = self.config.editor.huge_file_threshold;
+        let active_idx = self.focused_slot_idx();
+        let buf = self.slots[active_idx].editor.buffer();
+
+        let out = self
+            .syntax
+            .render_viewport(buffer_id, buf, top, height, huge);
+
+        if let Some(out) = out {
+            let start = out.key.1;
+            let end = start + out.spans.len();
+            self.slots[active_idx]
+                .editor
+                .patch_ratatui_syntax_spans_range(start..end, &out.spans);
+            self.slots[active_idx].diag_signs = out.signs;
+        } else {
+            // No spans available (no language, grammar loading, or huge file).
+            // Clear stale spans and let the renderer draw plain text.
+            self.slots[active_idx]
+                .editor
+                .install_ratatui_syntax_spans(Vec::new());
+        }
+
         self.refresh_git_signs();
-        self.last_git_us = t_git.elapsed().as_micros();
-        self.last_recompute_us = t_total.elapsed().as_micros();
-        tracing::debug!(
-            target: "hjkl::profile",
-            total_us = self.last_recompute_us,
-            install_us = self.last_install_us,
-            git_us = self.last_git_us,
-            submitted,
-            top, height,
-            dg,
-            "recompute_and_install"
-        );
-        let _ = submitted;
     }
 
-    /// Compute syntax highlight spans for a one-off preview snippet
-    /// (`path`, `bytes`). Used by the picker preview pane so the picker
-    /// itself stays bonsai-agnostic — sources only ship the buffer
-    /// contents and a path, this helper handles language resolution
-    /// and the actual highlighter call.
-    ///
-    /// Async-safe on the UI thread:
-    /// - **Cached** grammar → highlight immediately and return spans.
-    /// - **Loading** grammar → drop the handle (the bonsai pool keeps
-    ///   compiling) and return empty spans for this frame; the next
-    ///   call after the grammar lands picks up Cached.
-    /// - **Unknown** path → empty spans.
-    ///
-    /// The per-language `Highlighter` cache lives on `App` so a Rust
-    /// preview triggers one parser construction; subsequent Rust files
-    /// (or buffer/rg pickers in the same session) reuse it.
+    /// Compute syntax highlight spans for a one-off preview snippet.
     pub fn preview_spans_for(&self, path: &Path, bytes: &[u8]) -> PreviewSpans {
         self.preview_spans_for_range(path, bytes, 0..bytes.len())
     }
 
-    /// Viewport-clipped variant of [`Self::preview_spans_for`]. The parent
-    /// parse still runs over the full `bytes` (tree-sitter has no partial-
-    /// parse API for a fresh tree), but the injection scan + child highlights
-    /// are restricted to `byte_range`. For markdown — the only common grammar
-    /// with high injection density — this is the difference between paying
-    /// for every fence in the file vs. only the fences on screen.
+    /// Viewport-clipped variant of [`Self::preview_spans_for`].
     pub fn preview_spans_for_range(
         &self,
         path: &Path,
@@ -1075,11 +293,6 @@ impl App {
         };
         h.reset();
         h.parse_initial(bytes);
-        // Resolve injected languages via the async loader so unknown grammars
-        // kick off a background clone+compile (global spinner reflects this);
-        // returns None while loading so the parent renders without injection
-        // spans for now — the next preview tick after the grammar lands picks
-        // up the Cached fast path and fills in the children.
         let directory = std::sync::Arc::clone(&self.directory);
         let resolve = move |name: &str| match directory.request_by_name(name) {
             GrammarRequest::Cached(g) => Some(g),
@@ -1119,14 +332,6 @@ impl App {
     }
 
     /// `:syntax on` / `:syntax off` — toggle bonsai highlighting app-wide.
-    ///
-    /// `false` clears installed spans on every slot, drops per-slot install
-    /// caches, and short-circuits future `recompute_and_install` calls so
-    /// no parser thread work is queued.
-    ///
-    /// `true` re-registers the detected language for every slot's filename
-    /// (no-op for unnamed scratch buffers) and runs a fresh recompute for
-    /// the active slot so its viewport repaints immediately.
     pub(crate) fn set_syntax_enabled(&mut self, enabled: bool) {
         if self.syntax_enabled == enabled {
             return;
@@ -1136,11 +341,6 @@ impl App {
             for slot in &mut self.slots {
                 slot.editor.install_ratatui_syntax_spans(Vec::new());
                 slot.diag_signs.clear();
-                slot.viewport_render_output = None;
-                slot.last_sync_viewport_key = None;
-                slot.last_recompute_key = None;
-                slot.installed_spans_dg = None;
-                slot.installed_rows = None;
             }
         } else {
             for i in 0..self.slots.len() {
@@ -1154,48 +354,8 @@ impl App {
     }
 }
 
-/// Translate per-row span vectors in-place to track a batch of
-/// [`hjkl_engine::ContentEdit`]s. Generic over the row payload type so the
-/// same helper applies to cached `RenderOutput.spans`
-/// (`Vec<Vec<(usize, usize, StyleSpec)>>`) and any other row-keyed cache
-/// shape that needs to follow line count changes.
-///
-/// For each edit:
-/// - row count grew by N → insert N empty rows at index `old_end_row + 1`.
-/// - row count shrank by N → drain `(new_end_row + 1)..(old_end_row + 1)`.
-///
-/// Edits apply in order, each interpreted relative to the post-state of
-/// the prior edits in the batch (matching engine emission order).
-pub(crate) fn shift_rows<T>(rows: &mut Vec<Vec<T>>, edits: &[hjkl_engine::ContentEdit]) {
-    for edit in edits {
-        let oer = edit.old_end_position.0 as usize;
-        let ner = edit.new_end_position.0 as usize;
-        if ner == oer {
-            continue;
-        }
-        if ner > oer {
-            let n = ner - oer;
-            // O(len + n) via splice; the prior per-row `insert(idx, ...)`
-            // loop was O(n × (len - idx)) — see the matching fix in
-            // hjkl_engine::editor::shift_syntax_spans_for_edits.
-            let idx = (oer + 1).min(rows.len());
-            rows.splice(idx..idx, std::iter::repeat_with(Vec::new).take(n));
-        } else {
-            let n = oer - ner;
-            let len = rows.len();
-            let start = (ner + 1).min(len);
-            let end = (start + n).min(len);
-            if end > start {
-                rows.drain(start..end);
-            }
-        }
-    }
-}
-
 /// Number of off-screen rows above/below the visible window to include in the
-/// highlighter's byte range. Gives the injection query a buffer so a fenced
-/// code block whose opening backtick is just above the viewport (with content
-/// still on screen) still resolves its child grammar.
+/// highlighter's byte range for picker preview injection resolution.
 const VIEWPORT_SLACK_ROWS: usize = 50;
 
 /// Find the byte offset where row `target_row` begins (row 0 = byte 0). For
@@ -1217,8 +377,7 @@ fn byte_offset_of_row(bytes: &[u8], target_row: usize) -> usize {
 }
 
 /// Bridge: route `hjkl-picker`'s preview-pane highlighter through the
-/// editor's bonsai pipeline. Picker stays bonsai-agnostic — the trait
-/// impl lives consumer-side.
+/// editor's bonsai pipeline.
 impl hjkl_picker::PreviewHighlighter for App {
     fn spans_for(&self, path: &Path, bytes: &[u8]) -> PreviewSpans {
         self.preview_spans_for(path, bytes)
@@ -1272,99 +431,14 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn edit_insert_newline_at(row: u32, col: u32) -> hjkl_engine::ContentEdit {
-        hjkl_engine::ContentEdit {
-            start_byte: 0,
-            old_end_byte: 0,
-            new_end_byte: 1,
-            start_position: (row, col),
-            old_end_position: (row, col),
-            new_end_position: (row + 1, 0),
-        }
-    }
-
-    fn edit_join_rows(row: u32, col: u32) -> hjkl_engine::ContentEdit {
-        hjkl_engine::ContentEdit {
-            start_byte: 0,
-            old_end_byte: 1,
-            new_end_byte: 0,
-            start_position: (row, col),
-            old_end_position: (row + 1, 0),
-            new_end_position: (row, col),
-        }
-    }
-
-    fn marked_rows(n: usize) -> Vec<Vec<u8>> {
-        (0..n).map(|i| vec![i as u8]).collect()
-    }
-
-    #[test]
-    fn shift_rows_insertion_grows_in_place() {
-        let mut rows = marked_rows(4);
-        shift_rows(&mut rows, &[edit_insert_newline_at(1, 0)]);
-        assert_eq!(rows.len(), 5);
-        // Inserted empty row sits at oer+1 = 2.
-        assert!(rows[2].is_empty(), "inserted row must be empty");
-        // Untouched neighbours keep their marker bytes.
-        assert_eq!(rows[0], vec![0]);
-        assert_eq!(rows[1], vec![1]);
-        assert_eq!(rows[3], vec![2]);
-        assert_eq!(rows[4], vec![3]);
-    }
-
-    #[test]
-    fn shift_rows_deletion_shrinks_in_place() {
-        let mut rows = marked_rows(4);
-        shift_rows(&mut rows, &[edit_join_rows(1, 0)]);
-        assert_eq!(rows.len(), 3);
-        // Drained range was (ner+1)..(oer+1) = 2..3, so row 2 (marker `2`)
-        // disappears. Survivors: 0, 1, 3.
-        assert_eq!(rows[0], vec![0]);
-        assert_eq!(rows[1], vec![1]);
-        assert_eq!(rows[2], vec![3]);
-    }
-
-    #[test]
-    fn shift_rows_same_row_edit_is_noop() {
-        let mut rows = marked_rows(3);
-        let same_row = hjkl_engine::ContentEdit {
-            start_byte: 0,
-            old_end_byte: 0,
-            new_end_byte: 1,
-            start_position: (1, 0),
-            old_end_position: (1, 0),
-            new_end_position: (1, 1),
-        };
-        shift_rows(&mut rows, &[same_row]);
-        assert_eq!(rows.len(), 3);
-        assert_eq!(rows[0], vec![0]);
-        assert_eq!(rows[1], vec![1]);
-        assert_eq!(rows[2], vec![2]);
-    }
-
-    #[test]
-    fn shift_rows_ordered_edits_compose() {
-        let mut rows = marked_rows(3);
-        shift_rows(
-            &mut rows,
-            &[edit_insert_newline_at(0, 0), edit_insert_newline_at(1, 0)],
-        );
-        assert_eq!(rows.len(), 5);
-    }
-
-    /// Regression catcher for the picker preview injection wiring: a
-    /// markdown buffer with a fenced rust code block must produce
-    /// multiple styled spans on the rust line. If `preview_spans_for`
-    /// regresses to the non-injection `highlight_range` variant, the
-    /// rust row collapses to a single uniform span and this fails.
+    /// Regression: install_render_result no longer exists; the equivalent is
+    /// recompute_and_install. This test verifies the picker preview injection
+    /// wiring still works.
     #[test]
     #[ignore = "network + compiler: fetches markdown + rust grammars"]
     fn preview_spans_for_markdown_includes_rust_injection() {
         let app = App::new(None, false, None, None).unwrap();
 
-        // Force sync builds so the preview's async resolver hits Cached.
-        // Both calls block on first run; subsequent runs hit the on-disk
-        // cache instantly.
         assert!(
             app.directory.by_name("markdown").is_some(),
             "markdown grammar should resolve"
@@ -1378,12 +452,6 @@ mod tests {
         let path = PathBuf::from("test.md");
         let spans = app.preview_spans_for(&path, source);
 
-        // Row layout of the test source:
-        //   0: # Title
-        //   1: (blank)
-        //   2: ```rust
-        //   3: fn main() {}   ← injection target
-        //   4: ```
         const RUST_ROW: usize = 3;
         assert!(
             spans.by_row.len() > RUST_ROW,
@@ -1392,11 +460,6 @@ mod tests {
             spans.by_row.len()
         );
         let rust_row = &spans.by_row[RUST_ROW];
-
-        // Without injection the whole `fn main() {}` slice is one uniform
-        // markdown `code_fence_content` capture (≤ 1 styled span). With
-        // rust injection we expect distinct keyword + function + punctuation
-        // spans (≥ 3 styled regions in any theme that styles those captures).
         assert!(
             rust_row.len() >= 3,
             "expected ≥3 styled spans on the rust row (keyword/function/punct from injection); \
@@ -1405,286 +468,4 @@ mod tests {
             rust_row
         );
     }
-
-    /// Regression catcher for the async-highlight cross-buffer bug
-    /// (https://github.com/kryptic-sh/hjkl/issues/...): a parse submitted
-    /// against buffer A could complete after the user switched to buffer B,
-    /// and `recompute_and_install` would paint A's spans onto B because
-    /// the install path ignored `RenderOutput::buffer_id`.
-    ///
-    /// Manifested as: under PC lag, hjkl shows the previous tab's syntax
-    /// colors on the now-active tab until the next keystroke.
-    ///
-    /// This test calls `install_render_result` with a synthetic output
-    /// whose `buffer_id` does not match the active buffer and verifies
-    /// the install is dropped and `syntax_stale_drops` increments.
-    #[test]
-    fn install_render_result_drops_stale_buffer_id() {
-        use crate::syntax::{PerfBreakdown, RenderOutput};
-        use hjkl_buffer_tui::Sign;
-        use ratatui::style::{Color, Style};
-
-        let mut app = App::new(None, false, None, None).unwrap();
-
-        let active_id = app.active().buffer_id;
-        let stale_id = active_id.wrapping_add(999);
-
-        // Seed a recognisable diag_sign on the active buffer so we can
-        // detect whether a (stale) install overwrote it.
-        let sentinel = Sign {
-            row: 0,
-            ch: '!',
-            style: Style::default(),
-            priority: 1,
-        };
-        app.active_mut().diag_signs = vec![sentinel];
-
-        // Stale: install carries a buffer_id the active buffer doesn't match.
-        let stale_signs = vec![Sign {
-            row: 0,
-            ch: 'X',
-            style: Style::default().fg(Color::Red),
-            priority: 9,
-        }];
-        let stale = RenderOutput {
-            buffer_id: stale_id,
-            spans: vec![vec![(0, 1, Style::default().fg(Color::Red))]],
-            signs: stale_signs,
-            key: (0, 0, 0),
-            perf: PerfBreakdown::default(),
-            kind: crate::syntax::ParseKind::Viewport,
-            changed_ranges: Vec::new(),
-        };
-
-        let installed = app.install_render_result(stale);
-        assert!(
-            !installed,
-            "stale RenderOutput (mismatched buffer_id) must not install"
-        );
-        assert_eq!(
-            app.syntax_stale_drops, 1,
-            "stale_drops counter should increment when a result is dropped"
-        );
-        let signs = &app.active().diag_signs;
-        assert_eq!(
-            signs.len(),
-            1,
-            "active buffer's diag_signs must not be overwritten by stale install"
-        );
-        assert_eq!(
-            signs[0].ch, '!',
-            "sentinel sign survived: active buffer untouched"
-        );
-
-        // Matching install: same buffer_id as active — must apply.
-        let fresh = RenderOutput {
-            buffer_id: active_id,
-            spans: vec![vec![]],
-            signs: vec![Sign {
-                row: 0,
-                ch: 'G',
-                style: Style::default(),
-                priority: 5,
-            }],
-            key: (0, 0, 0),
-            perf: PerfBreakdown::default(),
-            kind: crate::syntax::ParseKind::Viewport,
-            changed_ranges: Vec::new(),
-        };
-        let installed = app.install_render_result(fresh);
-        assert!(installed, "matching buffer_id must install");
-        assert_eq!(
-            app.syntax_stale_drops, 1,
-            "valid install must not bump stale_drops counter"
-        );
-        assert_eq!(
-            app.active().diag_signs[0].ch,
-            'G',
-            "fresh signs replaced the sentinel"
-        );
-    }
-
-    /// T5a: oversize_height must not exceed the buffer's line count.
-    /// 5-line buffer, viewport_height=10 → oversize must clamp to 5.
-    #[test]
-    fn oversize_height_clamped_to_buffer_line_count() {
-        // The computation mirrors what recompute_and_install does:
-        //   oversize_top    = top.saturating_sub(height)
-        //   oversize_height = (height * 3).min(line_count - oversize_top)
-        let line_count: usize = 5;
-        let top: usize = 0;
-        let height: usize = 10;
-
-        let oversize_top = top.saturating_sub(height);
-        let oversize_height = height
-            .saturating_mul(3)
-            .min(line_count.saturating_sub(oversize_top));
-
-        assert_eq!(
-            oversize_top, 0,
-            "oversize_top must clamp to 0 when top < height"
-        );
-        assert_eq!(
-            oversize_height, 5,
-            "oversize_height must not exceed line_count (5)"
-        );
-    }
-
-    /// T5b: `install_render_result` must route a viewport result to the correct
-    /// non-active slot and populate `viewport_render_output`.
-    #[test]
-    fn install_render_result_routes_to_correct_slot() {
-        use crate::syntax::{ParseKind, PerfBreakdown, RenderOutput};
-        use ratatui::style::Style;
-        use std::path::PathBuf;
-
-        let mut app = App::new(None, false, None, None).unwrap();
-
-        // Open a second slot — gives us slot 0 (active) and slot 1.
-        let tmp = std::env::temp_dir().join("hjkl_test_route_slot.txt");
-        std::fs::write(&tmp, "hello\nworld\n").unwrap();
-        let slot1_idx = app.open_new_slot(PathBuf::from(&tmp)).unwrap();
-        let slot1_buf_id = app.slots()[slot1_idx].buffer_id;
-
-        // Build a synthetic viewport output tagged to slot 1's buffer_id.
-        // Tag the result with slot 1's current dirty_gen so the
-        // generation-aware install guard doesn't drop it as stale.
-        let target_spans = vec![
-            vec![(0usize, 5usize, Style::default())],
-            vec![(0usize, 5usize, Style::default())],
-        ];
-        let slot1_dg = app.slots()[slot1_idx].editor.buffer().dirty_gen();
-        let out = RenderOutput {
-            buffer_id: slot1_buf_id,
-            spans: target_spans.clone(),
-            signs: Vec::new(),
-            key: (slot1_dg, 0, 0),
-            perf: PerfBreakdown::default(),
-            kind: ParseKind::Viewport,
-            changed_ranges: Vec::new(),
-        };
-
-        // Active slot is still slot 0 — install must NOT touch it.
-        let active_id = app.active().buffer_id;
-        assert_ne!(
-            active_id, slot1_buf_id,
-            "precondition: slot 0 must be active"
-        );
-
-        let installed_on_active = app.install_render_result(out);
-        assert!(
-            !installed_on_active,
-            "result for non-active slot must not return true"
-        );
-
-        // The viewport cache on slot 1 must now hold the output.
-        let cached = app.slots()[slot1_idx]
-            .viewport_render_output
-            .as_ref()
-            .expect("viewport_render_output must be populated on slot 1");
-        assert_eq!(
-            cached.spans, target_spans,
-            "cached spans must match what was installed"
-        );
-
-        // Active slot 0 must be untouched.
-        assert_eq!(
-            app.syntax_stale_drops, 0,
-            "routing to non-active slot must not count as stale drop"
-        );
-
-        let _ = std::fs::remove_file(&tmp);
-    }
-
-    /// T5c: `switch_to` must install cached spans from `viewport_render_output`
-    /// when the dirty_gen matches.
-    #[test]
-    fn switch_to_installs_cached_spans() {
-        use crate::syntax::{ParseKind, PerfBreakdown, RenderOutput};
-        use ratatui::style::Style;
-        use std::path::PathBuf;
-
-        let mut app = App::new(None, false, None, None).unwrap();
-
-        let tmp = std::env::temp_dir().join("hjkl_test_switch_cached.txt");
-        std::fs::write(&tmp, "line1\nline2\n").unwrap();
-        let slot1_idx = app.open_new_slot(PathBuf::from(&tmp)).unwrap();
-        let slot1_buf_id = app.slots()[slot1_idx].buffer_id;
-        let current_dg = app.slots()[slot1_idx].editor.buffer().dirty_gen();
-
-        // Seed a known viewport cache into slot 1.
-        let cached_spans = vec![
-            vec![(0usize, 5usize, Style::default())],
-            vec![(0usize, 5usize, Style::default())],
-        ];
-        app.slots_mut()[slot1_idx].viewport_render_output = Some(RenderOutput {
-            buffer_id: slot1_buf_id,
-            spans: cached_spans.clone(),
-            signs: Vec::new(),
-            key: (current_dg, 0, 40),
-            perf: PerfBreakdown::default(),
-            kind: ParseKind::Viewport,
-            changed_ranges: Vec::new(),
-        });
-
-        // Switch to slot 1 — cached spans should be installed immediately.
-        app.switch_to(slot1_idx);
-
-        // After switch, slot 1 is active. We can't easily assert the
-        // internal span table but we can verify no panic and that the
-        // cache is still populated (not cleared) on a clean dirty_gen.
-        assert!(
-            app.slots()[slot1_idx].viewport_render_output.is_some(),
-            "viewport cache must survive a clean switch_to (dirty_gen matched)"
-        );
-
-        let _ = std::fs::remove_file(&tmp);
-    }
-
-    /// T5d: `switch_to` must drop the viewport cache when dirty_gen mismatches.
-    #[test]
-    fn switch_to_drops_stale_cache_when_dirty_gen_mismatch() {
-        use crate::syntax::{ParseKind, PerfBreakdown, RenderOutput};
-        use ratatui::style::Style;
-        use std::path::PathBuf;
-
-        let mut app = App::new(None, false, None, None).unwrap();
-
-        let tmp = std::env::temp_dir().join("hjkl_test_switch_stale.txt");
-        std::fs::write(&tmp, "line1\nline2\n").unwrap();
-        let slot1_idx = app.open_new_slot(PathBuf::from(&tmp)).unwrap();
-        let slot1_buf_id = app.slots()[slot1_idx].buffer_id;
-        let current_dg = app.slots()[slot1_idx].editor.buffer().dirty_gen();
-
-        // Seed viewport cache with an old dirty_gen.
-        let stale_dg = current_dg.wrapping_sub(1);
-        let stale_out = RenderOutput {
-            buffer_id: slot1_buf_id,
-            spans: vec![vec![(0usize, 5usize, Style::default())]],
-            signs: Vec::new(),
-            key: (stale_dg, 0, 40),
-            perf: PerfBreakdown::default(),
-            kind: ParseKind::Viewport,
-            changed_ranges: Vec::new(),
-        };
-        app.slots_mut()[slot1_idx].viewport_render_output = Some(stale_out);
-
-        // Switch to slot 1 — stale cache must be evicted.
-        app.switch_to(slot1_idx);
-
-        // Viewport cache must be None or refreshed (not stale_dg).
-        if let Some(cached) = &app.slots()[slot1_idx].viewport_render_output {
-            assert_ne!(
-                cached.key.0, stale_dg,
-                "viewport: stale cache must have been replaced, not re-installed"
-            );
-        }
-        // (If None, the cache was cleared and nothing re-populated yet — also correct.)
-
-        let _ = std::fs::remove_file(&tmp);
-    }
-
-    // (deleted: install_merged_spans_top_only and subsequent tests that exercised
-    // top_render_output / bottom_render_output / merge_render_outputs — all dead code
-    // after the Top/Bottom ParseKind removal.)
 }

--- a/apps/hjkl/src/app/tests/marks_registers.rs
+++ b/apps/hjkl/src/app/tests/marks_registers.rs
@@ -1346,3 +1346,99 @@ fn count_then_dot_5_dot_repeats_five_times() {
         "5. must repeat x 5 more times; got {lines_after_dot:?}"
     );
 }
+
+/// Regression: `{count}p` (5p, 10p, 100p) must paste the register
+/// `count` times. Drives through `macro_key_seq` so it exercises the
+/// full event-loop digit-buffering path (handle_keypress →
+/// pending_count.try_accumulate → keymap dispatch).
+#[test]
+fn count_p_pastes_register_count_times() {
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "x");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    // yy5p — linewise yank, then 5p.
+    macro_key_seq(&mut app, &[ck('y'), ck('y'), ck('5'), ck('p')]);
+
+    let lines = app.active().editor.buffer().lines().to_vec();
+    assert_eq!(
+        lines.len(),
+        6,
+        "5p on a 1-line linewise yank must produce 6 lines (1 + 5); got {lines:?}"
+    );
+    assert!(
+        lines.iter().all(|l| l == "x"),
+        "every line should be 'x'; got {lines:?}"
+    );
+}
+
+/// Regression: counts with embedded zeros (10p, 100p) must accumulate
+/// correctly through the event-loop digit-buffering path.
+#[test]
+fn count_with_zero_digits_pastes_correctly() {
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "x");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    // yy10p — linewise yank, then 10p.
+    macro_key_seq(&mut app, &[ck('y'), ck('y'), ck('1'), ck('0'), ck('p')]);
+
+    let lines = app.active().editor.buffer().lines().to_vec();
+    assert_eq!(
+        lines.len(),
+        11,
+        "10p must produce 11 lines (1 + 10); got {lines:?}"
+    );
+}
+
+/// Regression: charwise paste with count must also repeat. Charwise
+/// pastes take a different branch inside `do_paste` than linewise.
+#[test]
+fn count_p_charwise_yank_pastes_count_times() {
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "abc");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    // yl5p — charwise yank one char, then 5p.
+    macro_key_seq(&mut app, &[ck('y'), ck('l'), ck('5'), ck('p')]);
+
+    let first_line = app
+        .active()
+        .editor
+        .buffer()
+        .lines()
+        .first()
+        .cloned()
+        .unwrap_or_default();
+    // Started with "abc", yanked 'a', `5p` pastes 'a' 5 times after cursor (col 0):
+    // "a" + "aaaaa" + "bc" = "aaaaaabc".
+    assert_eq!(
+        first_line, "aaaaaabc",
+        "5p of charwise 'a' must produce 'aaaaaabc'; got {first_line:?}"
+    );
+}
+
+/// Regression: three-digit counts (100p) must accumulate correctly.
+#[test]
+fn count_100p_pastes_100_times() {
+    let mut app = App::new(None, false, None, None).unwrap();
+    seed_buffer(&mut app, "x");
+    app.active_mut().editor.jump_cursor(0, 0);
+    app.sync_viewport_from_editor();
+
+    macro_key_seq(
+        &mut app,
+        &[ck('y'), ck('y'), ck('1'), ck('0'), ck('0'), ck('p')],
+    );
+
+    let lines = app.active().editor.buffer().lines().to_vec();
+    assert_eq!(
+        lines.len(),
+        101,
+        "100p must produce 101 lines (1 + 100); got {} lines",
+        lines.len()
+    );
+}

--- a/apps/hjkl/src/app/tests/misc.rs
+++ b/apps/hjkl/src/app/tests/misc.rs
@@ -724,49 +724,6 @@ fn dispatch_action_stays_small() {
     );
 }
 
-/// `sync_after_engine_mutation` must append entries to `dirty_rows_log` whose
-/// `dirty_gen` matches the buffer's current gen and whose row range contains
-/// the row that was edited.
-#[test]
-fn sync_appends_edit_log_with_correct_dirty_gen() {
-    // Open a 5-line buffer.
-    let mut app = App::new(None, false, None, None).unwrap();
-    seed_buffer(&mut app, "a\nb\nc\nd\ne");
-    // Flush any edits from seeding so we start with a clean log.
-    app.sync_after_engine_mutation();
-    app.active_mut().dirty_rows_log.clear();
-
-    // Enter Insert mode on row 2 and type 'x' — this produces a ContentEdit
-    // with start_position.0 == 2.
-    app.active_mut().editor.jump_cursor(2, 0);
-    app.sync_viewport_from_editor();
-    enter_insert(&mut app);
-    dik(
-        &mut app,
-        crossterm::event::KeyEvent::new(
-            crossterm::event::KeyCode::Char('x'),
-            crossterm::event::KeyModifiers::NONE,
-        ),
-    );
-
-    // After sync the log must have at least one entry whose row range
-    // contains row 2, and whose dirty_gen matches the buffer's current gen.
-    let current_dg = app.active().editor.buffer().dirty_gen();
-    let log = &app.active().dirty_rows_log;
-    assert!(
-        !log.is_empty(),
-        "dirty_rows_log must have at least one entry after an edit"
-    );
-    let entry_for_row2 = log
-        .iter()
-        .find(|(dg, range)| *dg == current_dg && range.contains(&2));
-    assert!(
-        entry_for_row2.is_some(),
-        "dirty_rows_log must have an entry with dirty_gen={current_dg} containing row 2; \
-         log={log:?}"
-    );
-}
-
 // ── chord_timeout_ms config wiring tests ──────────────────────────────────
 
 /// App::new (no-config path) must seed the chord-timeout from the canonical

--- a/apps/hjkl/src/app/types.rs
+++ b/apps/hjkl/src/app/types.rs
@@ -303,12 +303,6 @@ pub struct BufferSlot {
     /// to throttle the libgit2 diff to ~4 Hz during active typing on
     /// large files.
     pub(super) last_git_refresh_at: Instant,
-    /// Wall-clock time of the last syntax recompute+install.
-    pub(super) last_recompute_at: Instant,
-    /// `(dirty_gen, vp_top, vp_height)` snapshot of the last call to
-    /// `recompute_and_install`. When the next call has identical
-    /// inputs, the syntax span recompute + install is skipped.
-    pub(super) last_recompute_key: Option<(u64, usize, usize)>,
     /// Hash + byte-length of the buffer content as it was at the most
     /// recent save (or load).
     pub(super) saved_hash: u64,
@@ -319,39 +313,6 @@ pub struct BufferSlot {
     pub disk_len: Option<u64>,
     /// Whether the on-disk file is in sync, changed, or deleted.
     pub disk_state: DiskState,
-    /// Most recent completed viewport-scoped `RenderOutput` for this buffer.
-    /// Cached so a buffer switch can immediately re-install the last known
-    /// spans while a fresh parse runs in the background (T3 — per-slot
-    /// span cache). `None` until the first viewport parse result arrives.
-    pub(crate) viewport_render_output: Option<crate::syntax::RenderOutput>,
-    /// Per-row edit log: each entry is `(dirty_gen, row_range)` where
-    /// `dirty_gen` is the buffer's `dirty_gen` AFTER the edit landed and
-    /// `row_range` is the inclusive row range touched by that edit.
-    ///
-    /// Used by `merge_render_outputs` so rows untouched since a cache's
-    /// parse are still painted from the cache, avoiding the "white flash"
-    /// where ALL spans vanish until the background worker returns.
-    ///
-    /// Capped at 256 entries to bound memory on long sessions.
-    pub(crate) dirty_rows_log: Vec<(u64, std::ops::RangeInclusive<usize>)>,
-    /// Last `(dirty_gen, range_top, range_height)` the sync
-    /// `query_viewport` was run with per `ParseKind`. Used by
-    /// `sync_query_region` to skip work when nothing changed since the
-    /// previous tick — without this guard `recompute_and_install`
-    /// re-runs the highlight + merge + install pipeline on every event
-    /// loop iteration even when the buffer is idle, which shows up as
-    /// scroll lag on large files.
-    pub(crate) last_sync_viewport_key: Option<(u64, usize, usize)>,
-    /// Per-row span install cache. Tracks the row range that has had
-    /// spans installed via `patch_ratatui_syntax_spans_range` for the
-    /// current `dirty_gen`. When the next viewport read's row range
-    /// already lies inside this range, the sync walk is skipped —
-    /// j/k scrolling within a previously-walked area becomes free.
-    /// When the viewport extends past the range, only the *delta* rows
-    /// are walked (cost proportional to scroll distance, not viewport
-    /// size). Invalidated on `dirty_gen` change.
-    pub(crate) installed_spans_dg: Option<u64>,
-    pub(crate) installed_rows: Option<std::ops::Range<usize>>,
 }
 
 /// Walk up from `start` looking for a project-root marker file.

--- a/apps/hjkl/src/render.rs
+++ b/apps/hjkl/src/render.rs
@@ -1225,20 +1225,42 @@ fn status_line(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 /// `current_idx` is 1-based (the match the cursor is on or just passed).
 /// Returns `None` when no pattern is active or there are no matches.
 /// Caps at 10 000 matches to avoid stalling on huge files.
+///
+/// Result is memoised on `App::search_count_cache` keyed by
+/// `(buffer_id, dirty_gen, cursor, pattern_text)` — the status line
+/// re-runs this every render, but the scan only re-runs when one of
+/// those changes. On a cache miss the scan walks
+/// `Buffer::content_joined` (cached `Arc<String>`) once with regex's
+/// SIMD-fast `find_iter`, translating each match position back to its
+/// row via the cumulative newline count instead of cloning per-line
+/// `Vec<String>`s.
 pub(crate) fn search_count(app: &App) -> Option<(usize, usize)> {
     const MATCH_CAP: usize = 10_000;
     let st = app.active().editor.search_state();
     let pat = st.pattern.as_ref()?;
+    let pattern_str = pat.as_str();
+
     let buf = app.active().editor.buffer();
-    let (cursor_row, cursor_col) = app.active().editor.cursor();
-    // The engine reports `cursor_col` as a char index, but `regex::Match::start`
-    // returns a byte offset. On lines with multi-byte chars before the match
-    // (e.g. an em-dash in a doc comment) byte > char and the comparison drops
-    // the match the cursor is sitting on. Convert the cursor to a byte offset
-    // on its own line so both sides of the inequality are byte-counted.
-    let cursor_byte = buf
-        .lines()
-        .get(cursor_row)
+    let buffer_id = app.active().buffer_id;
+    let dirty_gen = buf.dirty_gen();
+    let cursor = app.active().editor.cursor();
+
+    // Cache hit — return immediately.
+    if let Some(cached) = app.search_count_cache.borrow().as_ref()
+        && cached.buffer_id == buffer_id
+        && cached.dirty_gen == dirty_gen
+        && cached.cursor == cursor
+        && cached.pattern == pattern_str
+    {
+        return cached.result;
+    }
+
+    let (cursor_row, cursor_col) = cursor;
+
+    // `cursor_col` is a char index; regex match offsets are bytes.
+    // Convert cursor's column to a byte offset within its own line.
+    let cursor_byte_in_row = buf
+        .line(cursor_row)
         .map(|line| {
             line.char_indices()
                 .nth(cursor_col)
@@ -1246,24 +1268,55 @@ pub(crate) fn search_count(app: &App) -> Option<(usize, usize)> {
                 .unwrap_or(line.len())
         })
         .unwrap_or(0);
-    let mut total = 0usize;
-    let mut current_idx = 0usize;
-    'outer: for (row_idx, line) in buf.lines().iter().enumerate() {
-        for m in pat.find_iter(line) {
-            total += 1;
-            if (row_idx, m.start()) <= (cursor_row, cursor_byte) {
-                current_idx = total;
-            }
-            if total >= MATCH_CAP {
-                break 'outer;
+
+    // Single shared `Arc<String>` of the whole document — cached against
+    // `dirty_gen`, so calling content_joined here costs an `Arc::clone`.
+    let content = buf.content_joined();
+    let bytes = content.as_bytes();
+
+    // Compute cursor's global byte position in `content`. We walk newlines
+    // until we hit row `cursor_row` — capped by the row index, not file size.
+    let mut cursor_global_byte = 0usize;
+    if cursor_row > 0 {
+        let mut seen = 0usize;
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                seen += 1;
+                if seen == cursor_row {
+                    cursor_global_byte = i + 1;
+                    break;
+                }
             }
         }
     }
-    if total == 0 {
+    cursor_global_byte += cursor_byte_in_row;
+
+    let mut total = 0usize;
+    let mut current_idx = 0usize;
+    for m in pat.find_iter(&content) {
+        total += 1;
+        if m.start() <= cursor_global_byte {
+            current_idx = total;
+        }
+        if total >= MATCH_CAP {
+            break;
+        }
+    }
+    let result = if total == 0 {
         None
     } else {
         Some((current_idx, total))
-    }
+    };
+
+    *app.search_count_cache.borrow_mut() = Some(crate::app::SearchCountCache {
+        buffer_id,
+        dirty_gen,
+        cursor,
+        pattern: pattern_str.to_string(),
+        result,
+    });
+
+    result
 }
 
 /// Build the status line text as a ratatui [`Line`].

--- a/apps/hjkl/src/syntax.rs
+++ b/apps/hjkl/src/syntax.rs
@@ -1,13 +1,9 @@
 //! App-side syntax wiring shim.
 //!
-//! Delegates all background-thread machinery to [`hjkl_syntax::SyntaxLayer`]
-//! and [`hjkl_syntax::SyntaxWorker`]. This file is the TUI-side adapter:
-//! it converts [`hjkl_syntax::RenderOutput`] (renderer-agnostic
+//! Delegates to [`hjkl_syntax::SyntaxLayer`] (fully synchronous — no worker
+//! thread) and converts [`hjkl_syntax::RenderOutput`] (renderer-agnostic
 //! [`hjkl_theme::StyleSpec`] spans) to the ratatui-typed output that
 //! `syntax_glue.rs` installs onto the editor.
-//!
-//! **Public surface for `apps/hjkl` internal use only.** The agnostic types
-//! now live in `hjkl-syntax`; the TUI conversion lives in `hjkl-syntax-tui`.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -20,9 +16,7 @@ use hjkl_syntax_tui::render_output_to_tui;
 use hjkl_lang::LanguageDirectory;
 
 // Re-export agnostic types used by app/mod.rs and syntax_glue.rs.
-pub use hjkl_syntax::{
-    BufferId, LoadEvent, LoadEventKind, ParseKind, ParseKindKind, PerfBreakdown, SetLanguageOutcome,
-};
+pub use hjkl_syntax::{BufferId, LoadEvent, LoadEventKind, SetLanguageOutcome};
 
 // ---------------------------------------------------------------------------
 // TUI-typed RenderOutput (wiring shim)
@@ -30,35 +24,19 @@ pub use hjkl_syntax::{
 
 /// TUI-layer render output: spans have been converted to
 /// `ratatui::style::Style` by `hjkl-syntax-tui`.
-///
-/// Wraps the fields that `syntax_glue.rs` and `app/mod.rs` read directly.
 #[derive(Debug, Clone)]
 pub struct RenderOutput {
-    /// Buffer this result belongs to (same semantics as
-    /// [`hjkl_syntax::RenderOutput::buffer_id`]).
-    pub buffer_id: BufferId,
     /// Per-row span table with ratatui styles.
     pub spans: Vec<Vec<(usize, usize, ratatui::style::Style)>>,
     /// Diagnostic gutter signs (ratatui-styled via `hjkl-syntax-tui`).
     pub signs: Vec<Sign>,
     /// `(dirty_gen, viewport_top, viewport_height)` cache key.
     pub key: (u64, usize, usize),
-    /// Sub-step timing breakdown (available for perf_overlay; accessed via
-    /// `syntax.last_perf` on the layer rather than per-output in practice).
-    #[allow(dead_code)]
-    pub perf: PerfBreakdown,
-    /// Which region this result covers (Viewport / Top / Bottom).
-    pub kind: ParseKind,
-    /// Byte ranges tree-sitter reports as structurally changed since
-    /// the prior retained tree (forwarded from
-    /// [`hjkl_syntax::RenderOutput::changed_ranges`]).
-    pub changed_ranges: Vec<std::ops::Range<usize>>,
 }
 
 impl PartialEq for RenderOutput {
     fn eq(&self, other: &Self) -> bool {
-        self.kind == other.kind
-            && self.spans == other.spans
+        self.spans == other.spans
             && self.signs.len() == other.signs.len()
             && self
                 .signs
@@ -68,19 +46,13 @@ impl PartialEq for RenderOutput {
     }
 }
 
-/// Convert a [`hjkl_syntax::RenderOutput`] to the TUI-typed [`RenderOutput`]
-/// used by `syntax_glue.rs`. Spans and signs are materialised via
-/// `hjkl-syntax-tui`.
+/// Convert a [`hjkl_syntax::RenderOutput`] to the TUI-typed [`RenderOutput`].
 fn convert_output(raw: hjkl_syntax::RenderOutput) -> RenderOutput {
     let (spans, signs) = render_output_to_tui(&raw);
     RenderOutput {
-        buffer_id: raw.buffer_id,
         spans,
         signs,
         key: raw.key,
-        perf: raw.perf,
-        kind: raw.kind,
-        changed_ranges: raw.changed_ranges,
     }
 }
 
@@ -88,14 +60,10 @@ fn convert_output(raw: hjkl_syntax::RenderOutput) -> RenderOutput {
 // SyntaxLayer — TUI wiring shim
 // ---------------------------------------------------------------------------
 
-/// App-side syntax layer. Delegates background-thread work to
-/// [`hjkl_syntax::SyntaxLayer`] and converts outputs to ratatui types on
-/// the way out.
+/// App-side syntax layer. Delegates to [`hjkl_syntax::SyntaxLayer`] and
+/// converts outputs to ratatui types on the way out.
 pub struct SyntaxLayer {
     inner: hjkl_syntax::SyntaxLayer,
-    /// Last perf breakdown received. Kept here so `app/mod.rs` can read it
-    /// via `self.syntax.last_perf` without going through `inner`.
-    pub last_perf: PerfBreakdown,
 }
 
 impl SyntaxLayer {
@@ -103,20 +71,15 @@ impl SyntaxLayer {
     pub fn new(theme: Arc<dyn Theme + Send + Sync>, directory: Arc<LanguageDirectory>) -> Self {
         Self {
             inner: hjkl_syntax::SyntaxLayer::new(theme, directory),
-            last_perf: PerfBreakdown::default(),
         }
     }
 
-    /// Detect the language for `path` and ship it to the worker.
+    /// Detect the language for `path` and attach a grammar.
     pub fn set_language_for_path(&mut self, id: BufferId, path: &Path) -> SetLanguageOutcome {
         self.inner.set_language_for_path(id, path)
     }
 
-    /// Resolve a path to its canonical language name (e.g. `"rust"` for
-    /// `foo.rs`) without loading any grammar. Returns `None` for unknown
-    /// extensions. Used to seed `Editor::set_filetype` on file open so
-    /// filetype-aware features (`gcc`, comment continuation, …) light up
-    /// regardless of whether the grammar itself is installed yet.
+    /// Resolve a path to its canonical language name without loading any grammar.
     pub fn language_name_for_path(&self, path: &Path) -> Option<String> {
         self.inner.directory().name_for_path(path)
     }
@@ -136,145 +99,38 @@ impl SyntaxLayer {
         self.inner.set_theme(theme);
     }
 
-    /// Synchronous viewport-only preview render.
-    /// Returns `None` when no language is attached or the viewport is empty.
-    pub fn preview_render(
-        &self,
-        id: BufferId,
-        buffer: &impl Query,
-        viewport_top: usize,
-        viewport_height: usize,
-    ) -> Option<RenderOutput> {
-        let raw = self
-            .inner
-            .preview_render(id, buffer, viewport_top, viewport_height)?;
-        Some(convert_output(raw))
-    }
-
-    /// Borrow the buffer's cached `(source, row_starts, line_count, dirty_gen)`,
-    /// populated as a side-effect of [`Self::submit_render`]. Forwarded so
-    /// the app's render-path can drive a sync `query_viewport` against the
-    /// same source the worker will see. `dirty_gen` is the buffer's
-    /// generation at cache-build time — compare against the buffer's
-    /// current generation to detect a stale cache.
-    #[allow(clippy::type_complexity)]
-    pub fn cached_source(
-        &self,
-        id: BufferId,
-    ) -> Option<(
-        std::sync::Arc<String>,
-        std::sync::Arc<Vec<usize>>,
-        usize,
-        u64,
-    )> {
-        self.inner.cached_source(id)
-    }
-
-    /// Synchronous viewport highlight against the retained tree. See
-    /// [`hjkl_syntax::SyntaxLayer::query_viewport`].
-    #[allow(clippy::too_many_arguments)]
-    pub fn query_viewport(
-        &self,
-        id: BufferId,
-        source: &str,
-        row_starts: &[usize],
-        viewport_byte_range: std::ops::Range<usize>,
-        viewport_top: usize,
-        viewport_height: usize,
-        row_count: usize,
-        dirty_gen: u64,
-        kind: ParseKind,
-    ) -> Option<RenderOutput> {
-        let raw = self.inner.query_viewport(
-            id,
-            source,
-            row_starts,
-            viewport_byte_range,
-            viewport_top,
-            viewport_height,
-            row_count,
-            dirty_gen,
-            kind,
-        )?;
-        Some(convert_output(raw))
-    }
-
-    /// Ask the worker to drop this buffer's retained tree on the next parse.
+    /// Drop the buffer's retained tree. Next render_viewport reparses from scratch.
     pub fn reset(&mut self, id: BufferId) {
         self.inner.reset(id);
     }
 
-    /// Buffer a batch of engine `ContentEdit`s to be shipped to the worker
-    /// on the next `submit_render`.
+    /// Apply a batch of engine `ContentEdit`s to the retained tree synchronously.
     pub fn apply_edits(&mut self, id: BufferId, edits: &[hjkl_engine::ContentEdit]) {
         self.inner.apply_edits(id, edits);
     }
 
-    /// Submit a parse + render job to the worker. Returns `None` when no
-    /// language is attached; `Some(source_build_us)` on submit.
-    pub fn submit_render(
+    /// Render spans for the visible viewport. Fully synchronous.
+    pub fn render_viewport(
         &mut self,
         id: BufferId,
         buffer: &impl Query,
         viewport_top: usize,
         viewport_height: usize,
-        kind: ParseKind,
-    ) -> Option<u128> {
-        self.inner
-            .submit_render(id, buffer, viewport_top, viewport_height, kind)
-    }
-
-    /// Drain the most recent render result (oldest discarded).
-    #[allow(dead_code)]
-    pub fn take_result(&mut self) -> Option<RenderOutput> {
-        let raw = self.inner.take_result()?;
-        self.last_perf = raw.perf;
-        Some(convert_output(raw))
-    }
-
-    /// Drain all render results produced since the last drain.
-    pub fn take_all_results(&mut self) -> Vec<RenderOutput> {
-        let raws = self.inner.take_all_results();
-        if let Some(last) = raws.last() {
-            self.last_perf = last.perf;
-        }
-        raws.into_iter().map(convert_output).collect()
-    }
-
-    /// Block up to `timeout` for the next result, then drain any others.
-    pub fn wait_result(&mut self, timeout: std::time::Duration) -> Option<RenderOutput> {
-        let raw = self.inner.wait_result(timeout)?;
-        self.last_perf = raw.perf;
-        Some(convert_output(raw))
-    }
-
-    /// Block up to `timeout` for the first result, then drain ALL in arrival
-    /// order. Used for big-jump paths.
-    pub fn wait_all_results(&mut self, timeout: std::time::Duration) -> Vec<RenderOutput> {
-        let raws = self.inner.wait_all_results(timeout);
-        if let Some(last) = raws.last() {
-            self.last_perf = last.perf;
-        }
-        raws.into_iter().map(convert_output).collect()
-    }
-
-    /// Block up to `timeout` for the first result. Used at startup.
-    pub fn wait_for_initial_result(
-        &mut self,
-        timeout: std::time::Duration,
+        huge_file_threshold: u32,
     ) -> Option<RenderOutput> {
-        self.wait_result(timeout)
-    }
-
-    /// Test-only alias for [`Self::wait_for_initial_result`].
-    #[cfg(test)]
-    pub fn wait_for_result(&mut self, timeout: std::time::Duration) -> Option<RenderOutput> {
-        self.wait_for_initial_result(timeout)
+        let raw = self.inner.render_viewport(
+            id,
+            buffer,
+            viewport_top,
+            viewport_height,
+            huge_file_threshold,
+        )?;
+        Some(convert_output(raw))
     }
 }
 
 // ---------------------------------------------------------------------------
-// Factory helpers (kept for call-site compat in app/mod.rs)
+// Factory helpers
 // ---------------------------------------------------------------------------
 
 /// Build a `SyntaxLayer` using the given theme + language directory.
@@ -302,41 +158,12 @@ mod tests {
     use super::*;
     use hjkl_buffer::Buffer;
     use std::path::Path;
-    use std::time::Duration;
-
-    fn submit_and_wait(
-        layer: &mut SyntaxLayer,
-        buf: &Buffer,
-        top: usize,
-        height: usize,
-    ) -> Option<RenderOutput> {
-        layer.submit_render(TID, buf, top, height, ParseKind::Viewport)?;
-        layer.wait_for_result(Duration::from_secs(5))
-    }
 
     /// Test buffer id.
     const TID: BufferId = 0;
 
     #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn parse_and_render_small_rust_buffer() {
-        let buf = Buffer::from_str("fn main() { let x = 1; }\n");
-        let mut layer = default_layer();
-        assert!(
-            layer
-                .set_language_for_path(TID, Path::new("a.rs"))
-                .is_known()
-        );
-        let out = submit_and_wait(&mut layer, &buf, 0, 10).expect("worker output");
-        assert_eq!(out.spans.len(), buf.row_count());
-        assert!(
-            out.spans.iter().any(|r| !r.is_empty()),
-            "expected at least one styled span"
-        );
-    }
-
-    #[test]
-    fn submit_with_no_language_returns_none() {
+    fn render_viewport_with_no_language_returns_none() {
         let buf = Buffer::from_str("hello world");
         let mut layer = default_layer();
         assert!(
@@ -344,11 +171,7 @@ mod tests {
                 .set_language_for_path(TID, Path::new("a.unknownext"))
                 .is_known()
         );
-        assert!(
-            layer
-                .submit_render(TID, &buf, 0, 10, ParseKind::Viewport)
-                .is_none()
-        );
+        assert!(layer.render_viewport(TID, &buf, 0, 10, u32::MAX).is_none());
     }
 
     #[test]
@@ -364,121 +187,6 @@ mod tests {
         }];
         layer.apply_edits(TID, &edits);
         // No panic — that's the test.
-    }
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn first_load_highlights_entire_viewport() {
-        let mut content = String::new();
-        for i in 0..50 {
-            content.push_str(&format!("fn f{i}() {{ let x = {i}; }}\n"));
-        }
-        let buf = Buffer::from_str(content.strip_suffix('\n').unwrap_or(&content));
-
-        let mut layer = default_layer();
-        assert!(
-            layer
-                .set_language_for_path(TID, Path::new("a.rs"))
-                .is_known()
-        );
-        let out = submit_and_wait(&mut layer, &buf, 0, 30).unwrap();
-
-        for (r, row) in out.spans.iter().take(30).enumerate() {
-            assert!(
-                !row.is_empty(),
-                "row {r} has no highlight spans on first load (content: {:?})",
-                buf.line(r)
-            );
-        }
-    }
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn first_load_full_viewport_matches_full_parse() {
-        let mut content = String::new();
-        for i in 0..50 {
-            content.push_str(&format!("fn f{i}() {{ let x = {i}; }}\n"));
-        }
-        let buf = Buffer::from_str(content.strip_suffix('\n').unwrap_or(&content));
-
-        let mut narrow = default_layer();
-        narrow.set_language_for_path(TID, Path::new("a.rs"));
-        let narrow_out = submit_and_wait(&mut narrow, &buf, 0, 30).unwrap();
-
-        let mut full = default_layer();
-        full.set_language_for_path(TID, Path::new("a.rs"));
-        let full_out = submit_and_wait(&mut full, &buf, 0, 100).unwrap();
-
-        for r in 0..30 {
-            assert_eq!(
-                narrow_out.spans[r], full_out.spans[r],
-                "row {r} differs between viewport-scoped and full parse"
-            );
-        }
-    }
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn diagnostics_emit_sign_for_syntax_error() {
-        let buf = Buffer::from_str("fn main() {\nlet x = ;\n}\n");
-        let mut layer = default_layer();
-        layer.set_language_for_path(TID, Path::new("a.rs"));
-        let out = submit_and_wait(&mut layer, &buf, 0, 10).unwrap();
-        assert!(
-            !out.signs.is_empty(),
-            "expected at least one diagnostic sign for `let x = ;`"
-        );
-        assert!(
-            out.signs.iter().any(|s| s.row == 1 && s.ch == 'E'),
-            "expected an 'E' sign on row 1; got {:?}",
-            out.signs
-        );
-    }
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn diagnostics_clean_source_no_signs() {
-        let buf = Buffer::from_str("fn main() { let x = 1; }\n");
-        let mut layer = default_layer();
-        layer.set_language_for_path(TID, Path::new("a.rs"));
-        let out = submit_and_wait(&mut layer, &buf, 0, 10).unwrap();
-        assert!(
-            out.signs.is_empty(),
-            "expected no signs; got {:?}",
-            out.signs
-        );
-    }
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn incremental_path_matches_cold_for_small_edit() {
-        let pre = Buffer::from_str("fn main() { let x = 1; }");
-        let mut layer = default_layer();
-        layer.set_language_for_path(TID, Path::new("a.rs"));
-        let _ = submit_and_wait(&mut layer, &pre, 0, 10).unwrap();
-        layer.apply_edits(
-            TID,
-            &[hjkl_engine::ContentEdit {
-                start_byte: 3,
-                old_end_byte: 3,
-                new_end_byte: 4,
-                start_position: (0, 3),
-                old_end_position: (0, 3),
-                new_end_position: (0, 4),
-            }],
-        );
-        let post = Buffer::from_str("fn Ymain() { let x = 1; }");
-        let inc = submit_and_wait(&mut layer, &post, 0, 10).unwrap();
-        let mut cold_layer = default_layer();
-        cold_layer.set_language_for_path(TID, Path::new("a.rs"));
-        let cold = submit_and_wait(&mut cold_layer, &post, 0, 10).unwrap();
-        assert_eq!(inc.spans, cold.spans);
-    }
-
-    #[test]
-    fn worker_handles_quit_cleanly() {
-        let layer = default_layer();
-        drop(layer);
     }
 
     #[test]
@@ -503,123 +211,67 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "disk-state dependent: result depends on whether rust grammar is pre-installed"]
-    fn set_language_for_path_returns_loading_for_uncached_grammar() {
+    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
+    fn parse_and_render_small_rust_buffer() {
+        let buf = Buffer::from_str("fn main() { let x = 1; }\n");
         let mut layer = default_layer();
-        let t0 = std::time::Instant::now();
-        let outcome = layer.set_language_for_path(TID, Path::new("a.rs"));
-        let elapsed = t0.elapsed();
         assert!(
-            elapsed.as_millis() < 500,
-            "set_language_for_path blocked for {}ms — must be non-blocking",
-            elapsed.as_millis()
+            layer
+                .set_language_for_path(TID, Path::new("a.rs"))
+                .is_known()
         );
+        let out = layer
+            .render_viewport(TID, &buf, 0, 10, u32::MAX)
+            .expect("render output");
         assert!(
-            matches!(outcome, SetLanguageOutcome::Loading(_)),
-            "expected Loading on cold disk"
+            out.spans.iter().any(|r| !r.is_empty()),
+            "expected at least one styled span"
         );
     }
 
     #[test]
     #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn reset_pending_request_is_consumed_once() {
-        let buf = Buffer::from_str("fn main() {}");
+    fn diagnostics_emit_sign_for_syntax_error() {
+        let buf = Buffer::from_str("fn main() {\nlet x = ;\n}\n");
         let mut layer = default_layer();
         layer.set_language_for_path(TID, Path::new("a.rs"));
-        layer.reset(TID);
-        assert!(layer.inner.client_pending_reset(TID));
-        let _ = submit_and_wait(&mut layer, &buf, 0, 10).unwrap();
+        let out = layer.render_viewport(TID, &buf, 0, 10, u32::MAX).unwrap();
         assert!(
-            !layer.inner.client_pending_reset(TID),
-            "pending_reset should clear after submit"
+            !out.signs.is_empty(),
+            "expected at least one diagnostic sign for `let x = ;`"
+        );
+        assert!(
+            out.signs.iter().any(|s| s.row == 1 && s.ch == 'E'),
+            "expected an 'E' sign on row 1; got {:?}",
+            out.signs
         );
     }
 
     #[test]
     #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn forget_drops_buffer_state() {
-        let buf = Buffer::from_str("fn main() {}");
+    fn incremental_path_matches_cold_for_small_edit() {
+        let pre = Buffer::from_str("fn main() { let x = 1; }");
         let mut layer = default_layer();
         layer.set_language_for_path(TID, Path::new("a.rs"));
-        let _ = submit_and_wait(&mut layer, &buf, 0, 10).unwrap();
-        assert!(layer.inner.has_client(TID));
-        layer.forget(TID);
-        assert!(!layer.inner.has_client(TID));
-    }
-}
-
-#[cfg(test)]
-mod perf_smoke {
-    use super::*;
-    use hjkl_buffer::Buffer;
-    use std::path::Path;
-    use std::time::{Duration, Instant};
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn big_rs_smoke() {
-        let path = Path::new("/tmp/big.rs");
-        if !path.exists() {
-            eprintln!("/tmp/big.rs not present; skipping perf smoke");
-            return;
-        }
-        let content = std::fs::read_to_string(path).unwrap();
-        let buf = Buffer::from_str(content.strip_suffix('\n').unwrap_or(&content));
-        let mut layer = default_layer();
-        const TID: BufferId = 0;
-        assert!(layer.set_language_for_path(TID, path).is_known());
-
-        let t0 = Instant::now();
-        layer.submit_render(TID, &buf, 0, 50, ParseKind::Viewport);
-        let main_t = t0.elapsed();
-        let out = layer.wait_for_result(Duration::from_secs(10));
-        eprintln!(
-            "first submit_render main-thread: {:?}, worker turnaround total: {:?}",
-            main_t,
-            t0.elapsed()
-        );
-        assert!(out.is_some(), "first parse should produce output");
-
-        let t0 = Instant::now();
-        let mut main_total = Duration::ZERO;
-        for top in 0..100 {
-            let s = Instant::now();
-            layer.submit_render(TID, &buf, top * 100, 50, ParseKind::Viewport);
-            main_total += s.elapsed();
-        }
-        while layer.take_result().is_some() {}
-        eprintln!(
-            "100 viewport scrolls: total wall {:?}, main-thread total {:?} (avg {:?}/submit)",
-            t0.elapsed(),
-            main_total,
-            main_total / 100
-        );
-
-        let lines = buf.lines().to_vec();
-        let mut new_lines = lines.clone();
-        new_lines[50_000].insert(0, 'X');
-        let post = Buffer::from_str(&new_lines.join("\n"));
-        let edit_byte = (0..50_000).map(|r| lines[r].len() + 1).sum::<usize>();
+        let _ = layer.render_viewport(TID, &pre, 0, 10, u32::MAX).unwrap();
         layer.apply_edits(
             TID,
             &[hjkl_engine::ContentEdit {
-                start_byte: edit_byte,
-                old_end_byte: edit_byte,
-                new_end_byte: edit_byte + 1,
-                start_position: (50_000, 0),
-                old_end_position: (50_000, 0),
-                new_end_position: (50_000, 1),
+                start_byte: 3,
+                old_end_byte: 3,
+                new_end_byte: 4,
+                start_position: (0, 3),
+                old_end_position: (0, 3),
+                new_end_position: (0, 4),
             }],
         );
-        let t = Instant::now();
-        layer.submit_render(TID, &post, 0, 50, ParseKind::Viewport);
-        let main_us = t.elapsed();
-        let out = layer.wait_for_result(Duration::from_secs(10));
-        eprintln!(
-            "post-edit submit: main-thread {:?}, worker total {:?} (per-step: {:?})",
-            main_us,
-            t.elapsed(),
-            out.as_ref().map(|o| o.perf),
-        );
+        let post = Buffer::from_str("fn Ymain() { let x = 1; }");
+        let inc = layer.render_viewport(TID, &post, 0, 10, u32::MAX).unwrap();
+        let mut cold_layer = default_layer();
+        cold_layer.set_language_for_path(TID, Path::new("a.rs"));
+        let cold = cold_layer
+            .render_viewport(TID, &post, 0, 10, u32::MAX)
+            .unwrap();
+        assert_eq!(inc.spans, cold.spans);
     }
 }

--- a/crates/hjkl-compat-oracle/corpus/tier1.toml
+++ b/crates/hjkl-compat-oracle/corpus/tier1.toml
@@ -374,6 +374,42 @@ keys = "yyp"
 expected_buffer = "foo\nfoo\nbar\n"
 expected_cursor = [1, 0]
 
+# {count}p — paste linewise yank N times
+[[cases]]
+name = "register_yy_5p_pastes_five_times"
+initial_buffer = "x\n"
+initial_cursor = [0, 0]
+keys = "yy5p"
+expected_buffer = "x\nx\nx\nx\nx\nx\n"
+expected_cursor = [5, 0]
+
+# {count}p with embedded zero — 10p
+[[cases]]
+name = "register_yy_10p_pastes_ten_times"
+initial_buffer = "x\n"
+initial_cursor = [0, 0]
+keys = "yy10p"
+expected_buffer = "x\nx\nx\nx\nx\nx\nx\nx\nx\nx\nx\n"
+expected_cursor = [10, 0]
+
+# {count}P — paste-before linewise with count
+[[cases]]
+name = "register_yy_3P_pastes_three_times_before"
+initial_buffer = "x\n"
+initial_cursor = [0, 0]
+keys = "yy3P"
+expected_buffer = "x\nx\nx\nx\n"
+expected_cursor = [2, 0]
+
+# {count}p charwise — yank one char, paste N times after cursor
+[[cases]]
+name = "register_yl_5p_charwise_pastes_five_times"
+initial_buffer = "abc\n"
+initial_cursor = [0, 0]
+keys = "yl5p"
+expected_buffer = "aaaaaabc\n"
+expected_cursor = [0, 5]
+
 [[cases]]
 name = "register_ayy_yank_to_named"
 initial_buffer = "hello\nworld\n"

--- a/crates/hjkl-engine/src/vim.rs
+++ b/crates/hjkl-engine/src/vim.rs
@@ -7023,6 +7023,16 @@ fn do_paste<H: crate::types::Host>(
     // the final paste, `]` = last inserted char of the final paste.
     // We track (lo, hi) across iterations; the last value wins.
     let mut paste_mark: Option<((usize, usize), (usize, usize))> = None;
+    // Capture the cursor row before any paste iterations. Vim's
+    // linewise `[count]p` lands the cursor on the FIRST pasted line
+    // (original_row + 1), not on the last iteration's paste row.
+    // Without this snapshot the per-iteration cursor advancement leaves
+    // the cursor at `original_row + count` instead.
+    let original_row_for_linewise_after = if linewise && !before {
+        Some(buf_cursor_pos(&ed.buffer).row)
+    } else {
+        None
+    };
     for _ in 0..count {
         ed.sync_buffer_content_from_textarea();
         let yank = yank.clone();
@@ -7085,6 +7095,16 @@ fn do_paste<H: crate::types::Host>(
     if let Some((lo, hi)) = paste_mark {
         ed.set_mark('[', lo);
         ed.set_mark(']', hi);
+    }
+    // Linewise `p` (after) with count: cursor lands on the FIRST pasted
+    // line (original_row + 1) — vim parity. The per-iteration loop
+    // moves cursor to each paste's target_row, so without this reset
+    // `5p` would land at original_row + 5 instead of original_row + 1.
+    if let Some(orig_row) = original_row_for_linewise_after {
+        let first_target = orig_row.saturating_add(1);
+        buf_set_cursor_rc(&mut ed.buffer, first_target, 0);
+        crate::motions::move_first_non_blank(&mut ed.buffer);
+        ed.push_buffer_cursor_to_textarea();
     }
     // Any paste re-anchors the sticky column to the new cursor position.
     ed.sticky_col = Some(buf_cursor_pos(&ed.buffer).col);

--- a/crates/hjkl-syntax-tui/src/lib.rs
+++ b/crates/hjkl-syntax-tui/src/lib.rs
@@ -8,11 +8,11 @@
 //! # Quick-start
 //!
 //! ```rust
-//! use hjkl_syntax::{DiagSign, RenderOutput, PerfBreakdown, ParseKind};
+//! use hjkl_syntax::{DiagSign, RenderOutput, PerfBreakdown};
 //! use hjkl_syntax_tui::{to_ratatui_spans, diag_signs_to_buffer_signs};
 //!
 //! // An empty output with no spans and no signs.
-//! let out = RenderOutput::new(0, vec![], vec![], (0, 0, 10), PerfBreakdown::new(), ParseKind::Viewport);
+//! let out = RenderOutput::new(0, vec![], vec![], (0, 0, 10), PerfBreakdown::new());
 //! let rows = to_ratatui_spans(&out.spans);
 //! assert!(rows.is_empty());
 //!
@@ -125,7 +125,7 @@ pub fn diag_signs_to_buffer_signs(signs: &[DiagSign]) -> Vec<Sign> {
 /// # Examples
 ///
 /// ```rust
-/// use hjkl_syntax::{RenderOutput, PerfBreakdown, ParseKind};
+/// use hjkl_syntax::{RenderOutput, PerfBreakdown};
 /// use hjkl_syntax_tui::render_output_to_tui;
 ///
 /// let out = RenderOutput::new(
@@ -134,7 +134,6 @@ pub fn diag_signs_to_buffer_signs(signs: &[DiagSign]) -> Vec<Sign> {
 ///     vec![],
 ///     (1, 0, 30),
 ///     PerfBreakdown::new(),
-///     ParseKind::Viewport,
 /// );
 /// let (spans, signs) = render_output_to_tui(&out);
 /// assert_eq!(spans.len(), 1);

--- a/crates/hjkl-syntax-tui/src/lib.rs
+++ b/crates/hjkl-syntax-tui/src/lib.rs
@@ -155,7 +155,7 @@ pub fn render_output_to_tui(out: &RenderOutput) -> (Vec<Vec<(usize, usize, Style
 mod tests {
     use super::*;
     use hjkl_syntax::{
-        Color as ThemeColor, DiagSign, Modifiers, ParseKind, PerfBreakdown, RenderOutput, StyleSpec,
+        Color as ThemeColor, DiagSign, Modifiers, PerfBreakdown, RenderOutput, StyleSpec,
     };
     use ratatui::style::Modifier;
 
@@ -266,14 +266,7 @@ mod tests {
 
     #[test]
     fn render_output_to_tui_empty() {
-        let out = RenderOutput::new(
-            0,
-            vec![],
-            vec![],
-            (0, 0, 10),
-            PerfBreakdown::new(),
-            ParseKind::Viewport,
-        );
+        let out = RenderOutput::new(0, vec![], vec![], (0, 0, 10), PerfBreakdown::new());
         let (spans, signs) = render_output_to_tui(&out);
         assert!(spans.is_empty());
         assert!(signs.is_empty());
@@ -287,7 +280,6 @@ mod tests {
             vec![DiagSign::new(0, 'E', 100)],
             (3, 0, 10),
             PerfBreakdown::new(),
-            ParseKind::Viewport,
         );
         let (spans, signs) = render_output_to_tui(&out);
         assert_eq!(spans.len(), 1);

--- a/crates/hjkl-syntax/src/lib.rs
+++ b/crates/hjkl-syntax/src/lib.rs
@@ -1,29 +1,18 @@
 //! Renderer-agnostic syntax-highlighting pipeline for the hjkl editor stack.
 //!
-//! Owns a [`SyntaxWorker`] background thread (holding the `Highlighter`
-//! and retained `tree_sitter::Tree`) plus a main-thread `RenderCache` of
-//! `(source, row_starts)`. Call
-//! [`SyntaxLayer::set_language_for_path`] after opening a file, then
-//! [`SyntaxLayer::apply_edits`] for each frame's queued
-//! [`hjkl_engine::ContentEdit`] batch and [`SyntaxLayer::submit_render`]
-//! to enqueue a parse + viewport-scoped highlight on the worker. Drain
-//! results via [`SyntaxLayer::take_all_results`] each frame and route them
-//! to the correct per-slot cache field.
-//!
-//! # Design
+//! Fully synchronous: parse and highlight run on the main thread.
+//! Call [`SyntaxLayer::set_language_for_path`] after opening a file,
+//! [`SyntaxLayer::apply_edits`] after each batch of [`hjkl_engine::ContentEdit`]s,
+//! and [`SyntaxLayer::render_viewport`] to get styled spans for the visible rows.
 //!
 //! Output is renderer-agnostic: [`RenderOutput::spans`] carries
-//! `(byte_start, byte_end, `[`StyleSpec`]`)` triples rather than
-//! renderer-specific style types.  A TUI adapter ([`hjkl-syntax-tui`]) maps
-//! these to `ratatui::style::Style`; a future GUI adapter will map them to
-//! `cosmic_text` attributes.
-//!
-//! [`StyleSpec`]: hjkl_theme::StyleSpec
+//! `(byte_start, byte_end, [`StyleSpec`])` triples.
+//! A TUI adapter ([`hjkl-syntax-tui`]) maps these to `ratatui::style::Style`.
 
 use std::collections::HashMap;
+use std::ops::Range;
 use std::path::Path;
-use std::sync::{Arc, Condvar, Mutex};
-use std::thread::{self, JoinHandle};
+use std::sync::Arc;
 
 use hjkl_bonsai::runtime::{Grammar, LoadHandle};
 use hjkl_bonsai::{
@@ -31,14 +20,11 @@ use hjkl_bonsai::{
     Highlighter, InputEdit, MetaValue, Point, Theme,
 };
 use hjkl_engine::Query;
-
 use hjkl_lang::{GrammarRequest, LanguageDirectory};
 
 pub use hjkl_theme::{Color, Modifiers, StyleSpec};
 
-/// Stable identifier for an open buffer. Assigned by the App; carried
-/// through every syntax-pipeline message so the worker can multiplex
-/// per-buffer tree state.
+/// Stable identifier for an open buffer.
 ///
 /// # Examples
 ///
@@ -53,29 +39,7 @@ pub use hjkl_buffer::BufferId;
 // Public output types
 // ---------------------------------------------------------------------------
 
-/// Discriminates the purpose of a parse request / result so the App can
-/// route it to the correct per-slot cache field.
-///
-/// - `Viewport` — the current visible region.
-///
-/// # Examples
-///
-/// ```
-/// use hjkl_syntax::ParseKind;
-/// assert_eq!(ParseKind::Viewport, ParseKind::Viewport);
-/// ```
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ParseKind {
-    /// The current visible viewport region.
-    Viewport,
-}
-
 /// A single diagnostic sign emitted from the syntax pipeline.
-///
-/// Carries only renderer-agnostic fields: `row`, `ch`, and `priority`.
-/// The TUI adapter converts these to ratatui-styled `hjkl_buffer::Sign`
-/// objects using its own colour choices.
 ///
 /// # Examples
 ///
@@ -114,16 +78,14 @@ impl DiagSign {
     /// use hjkl_syntax::DiagSign;
     /// let s = DiagSign::new(1, 'E', 100);
     /// assert_eq!(s.row, 1);
-    /// assert_eq!(s.ch, 'E');
-    /// assert_eq!(s.priority, 100);
     /// ```
     pub fn new(row: usize, ch: char, priority: u8) -> Self {
         Self { row, ch, priority }
     }
 }
 
-/// Per-call sub-step timings exposed to apps' `:perf` overlay.
-/// Recorded on the worker side and shipped back inside [`RenderOutput`].
+/// Per-call sub-step timings. Kept for API compat (PerfBreakdown is re-exported
+/// in the TUI shim and referenced from `:perf` overlay code).
 ///
 /// # Examples
 ///
@@ -162,54 +124,31 @@ impl PerfBreakdown {
     }
 }
 
-/// Per-frame output of the syntax worker.
+/// Per-frame output of the syntax pipeline.
 ///
-/// Contains the styled span table (one inner `Vec` per document row), the
-/// diagnostic signs for the gutter, the cache key the request was tagged
-/// with, and a [`PerfBreakdown`] describing where the worker spent its time.
-///
-/// Spans use [`StyleSpec`] (renderer-agnostic). The TUI adapter
-/// ([`hjkl-syntax-tui`]) converts these to `ratatui::style::Style`.
+/// Contains the styled span table (one inner `Vec` per document row) and the
+/// diagnostic signs for the gutter.
 ///
 /// # Examples
 ///
 /// ```
-/// use hjkl_syntax::{RenderOutput, ParseKind, PerfBreakdown};
-/// let out = RenderOutput::new(0, Vec::new(), Vec::new(), (0, 0, 0), PerfBreakdown::default(), ParseKind::Viewport);
-/// assert_eq!(out.kind, ParseKind::Viewport);
+/// use hjkl_syntax::{RenderOutput, PerfBreakdown};
+/// let out = RenderOutput::new(0, Vec::new(), Vec::new(), (0, 0, 0), PerfBreakdown::default());
+/// assert_eq!(out.buffer_id, 0);
 /// ```
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct RenderOutput {
-    /// Routes spans/signs back to the matching buffer slot in App::slots.
-    /// Install path discards the result when this doesn't match the now-active
-    /// buffer (race fix: a parse queued before a tab/buffer switch must not
-    /// paint onto the new active buffer).
+    /// Routes spans/signs back to the matching buffer slot.
     pub buffer_id: BufferId,
-    /// Per-row span table. Each inner `Vec` contains `(byte_start, byte_end,
-    /// StyleSpec)` triples for the characters on that row. The outer index is
-    /// the document row (0-indexed). The table is sized to `row_count` even
-    /// when only a viewport slice was requested — rows outside the viewport
-    /// have empty inner Vecs.
+    /// Per-row span table.
     pub spans: Vec<Vec<(usize, usize, StyleSpec)>>,
-    /// Diagnostic signs for the gutter (one per row with a tree-sitter
-    /// ERROR / MISSING node intersecting the viewport).
+    /// Diagnostic signs for the gutter.
     pub signs: Vec<DiagSign>,
-    /// `(dirty_gen, viewport_top, viewport_height)` — same shape the App
-    /// uses for its own cache key. Pair the result with this on receive.
+    /// `(dirty_gen, viewport_top, viewport_height)` cache key.
     pub key: (u64, usize, usize),
-    /// Sub-step timing breakdown from the worker.
+    /// Sub-step timing breakdown (zeroed in fully-sync path).
     pub perf: PerfBreakdown,
-    /// Which region this result covers — used by the install path to route
-    /// into the correct per-slot cache field.
-    pub kind: ParseKind,
-    /// Byte ranges that tree-sitter reports as structurally changed
-    /// between the prior retained tree (with edits applied) and the
-    /// freshly-parsed tree. Empty on initial parse or when no structural
-    /// change occurred. The app uses this to refresh only the rows that
-    /// actually changed instead of re-walking the full viewport (the
-    /// remaining 25ms per keystroke).
-    pub changed_ranges: Vec<std::ops::Range<usize>>,
 }
 
 impl RenderOutput {
@@ -218,10 +157,9 @@ impl RenderOutput {
     /// # Examples
     ///
     /// ```
-    /// use hjkl_syntax::{RenderOutput, ParseKind, PerfBreakdown};
-    /// let out = RenderOutput::new(1, Vec::new(), Vec::new(), (7, 0, 30), PerfBreakdown::new(), ParseKind::Viewport);
+    /// use hjkl_syntax::{RenderOutput, PerfBreakdown};
+    /// let out = RenderOutput::new(1, Vec::new(), Vec::new(), (7, 0, 30), PerfBreakdown::new());
     /// assert_eq!(out.buffer_id, 1);
-    /// assert_eq!(out.kind, ParseKind::Viewport);
     /// ```
     pub fn new(
         buffer_id: BufferId,
@@ -229,7 +167,6 @@ impl RenderOutput {
         signs: Vec<DiagSign>,
         key: (u64, usize, usize),
         perf: PerfBreakdown,
-        kind: ParseKind,
     ) -> Self {
         Self {
             buffer_id,
@@ -237,16 +174,13 @@ impl RenderOutput {
             signs,
             key,
             perf,
-            kind,
-            changed_ranges: Vec::new(),
         }
     }
 }
 
 impl PartialEq for RenderOutput {
     fn eq(&self, other: &Self) -> bool {
-        self.kind == other.kind
-            && self.spans == other.spans
+        self.spans == other.spans
             && self.signs.len() == other.signs.len()
             && self
                 .signs
@@ -262,9 +196,6 @@ impl PartialEq for RenderOutput {
 
 /// Outcome of [`SyntaxLayer::set_language_for_path`].
 ///
-/// Callers that previously tested the return value as a `bool` should use
-/// `outcome.is_known()` for equivalent behaviour.
-///
 /// # Examples
 ///
 /// ```
@@ -275,28 +206,22 @@ impl PartialEq for RenderOutput {
 /// ```
 #[non_exhaustive]
 pub enum SetLanguageOutcome {
-    /// Grammar was already cached (or found fresh on disk) — installed
-    /// immediately. Buffer will highlight on the next render.
+    /// Grammar was already cached — installed immediately.
     Ready,
-    /// Grammar is being fetched/compiled on the background pool. Buffer
-    /// renders as plain text until [`SyntaxLayer::poll_pending_loads`] fires
-    /// the `Ready` event for this buffer. The inner `String` is the language
-    /// name (useful for status-line indicators).
+    /// Grammar is being fetched/compiled on the background pool.
     Loading(#[allow(dead_code)] String),
     /// Extension unrecognized. No grammar — plain text only.
     Unknown,
 }
 
 impl SetLanguageOutcome {
-    /// `true` when a grammar was found (either already cached or now in
-    /// flight). Drop-in replacement for the old `bool` return value.
+    /// `true` when a grammar was found (either already cached or now in flight).
     pub fn is_known(&self) -> bool {
         matches!(self, Self::Ready | Self::Loading(_))
     }
 }
 
-/// Event emitted by [`SyntaxLayer::poll_pending_loads`] for each handle that
-/// resolved during the tick.
+/// Event emitted by [`SyntaxLayer::poll_pending_loads`].
 ///
 /// # Examples
 ///
@@ -306,609 +231,622 @@ impl SetLanguageOutcome {
 /// match e {
 ///     LoadEvent::Ready { id, name } => assert_eq!(name, "rust"),
 ///     LoadEvent::Failed { .. } => panic!("unexpected"),
-///     // LoadEvent is #[non_exhaustive] — handle future variants.
 ///     _ => {}
 /// }
 /// ```
 #[non_exhaustive]
 pub enum LoadEvent {
-    /// Grammar installed; trigger a redraw + re-submit for `id`.
-    Ready {
-        /// The buffer id the grammar was loaded for.
-        id: BufferId,
-        /// The resolved language name (e.g. `"rust"`).
-        name: String,
-    },
-    /// Load failed (clone/compile error); buffer stays plain text.
+    /// Grammar installed; trigger a redraw + re-render for `id`.
+    Ready { id: BufferId, name: String },
+    /// Load failed; buffer stays plain text.
     Failed {
-        /// The buffer id the grammar was loaded for.
         id: BufferId,
-        /// The resolved language name.
         name: String,
-        /// Human-readable error message.
         error: String,
     },
 }
 
-/// Exhaustive view of a [`LoadEvent`] for use in
-/// [`SyntaxLayer::dispatch_load_event`] callbacks.
-///
-/// Unlike [`LoadEvent`] (which is `#[non_exhaustive]`), matching on this enum
-/// requires no wildcard arm and produces a compile error when new variants are
-/// added.
+/// Exhaustive view of a [`LoadEvent`] for dispatch callbacks.
 #[derive(Debug)]
 pub enum LoadEventKind<'a> {
     /// Grammar installed successfully.
-    Ready {
-        /// The buffer id the grammar was loaded for.
-        id: BufferId,
-        /// The resolved language name.
-        name: &'a str,
-    },
+    Ready { id: BufferId, name: &'a str },
     /// Grammar load failed.
     Failed {
-        /// The buffer id the grammar was loaded for.
         id: BufferId,
-        /// The resolved language name.
         name: &'a str,
-        /// Human-readable error message.
         error: &'a str,
     },
 }
 
-/// Exhaustive view of a [`ParseKind`] for use in
-/// [`SyntaxLayer::dispatch_parse_kind`] callbacks.
-///
-/// Unlike [`ParseKind`] (which is `#[non_exhaustive]`), matching on this enum
-/// requires no wildcard arm.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ParseKindKind {
-    /// The current visible viewport region.
-    Viewport,
+// ---------------------------------------------------------------------------
+// In-flight grammar load tracking
+// ---------------------------------------------------------------------------
+
+struct PendingLoad {
+    id: BufferId,
+    name: String,
+    handle: LoadHandle,
 }
 
 // ---------------------------------------------------------------------------
-// Internal types
+// Per-buffer client state (main thread)
 // ---------------------------------------------------------------------------
 
-/// Cached `(source, row_starts)` keyed off buffer identity (dirty_gen +
-/// shape). Built once per buffer mutation on the **main** thread and
-/// shipped to the worker as `Arc`s so the worker doesn't memcpy a 1.3 MB
-/// Rust file for every parse request.
-struct RenderCache {
-    dirty_gen: u64,
-    len_bytes: usize,
-    line_count: u32,
-    source: Arc<String>,
-    row_starts: Arc<Vec<usize>>,
+/// Per-buffer state owned by the main-thread [`SyntaxLayer`].
+struct BufferClient {
+    has_language: bool,
+    current_lang: Option<Arc<Grammar>>,
+    /// Owns Parser + Tree for this buffer.
+    highlighter: Option<Highlighter>,
+    /// dirty_gen the cache was built at (None = cache absent).
+    cache_dirty_gen: Option<u64>,
+    /// Contiguous row range covered by `cache_spans`.
+    cache_rows: Range<usize>,
+    /// Per-row span table for `cache_rows`.
+    cache_spans: Vec<Vec<(usize, usize, StyleSpec)>>,
+    /// `(dirty_gen, row_starts)` — rebuilt only when dirty_gen changes.
+    cache_row_starts: Option<(u64, Arc<Vec<usize>>)>,
+    /// dirty_gen of the most recent successful parse. Gate reparsing.
+    parsed_dirty_gen: Option<u64>,
+    /// Cached diag signs keyed by `(dirty_gen, vp_top, vp_end)`.
+    cache_signs: Option<(u64, usize, usize, Vec<DiagSign>)>,
 }
 
-/// A parse + render job submitted to the worker. The worker reparses
-/// against the (already-edited) retained tree, runs the viewport
-/// highlight + error scan, builds the per-row span table, and sends the
-/// result back via mpsc.
-///
-/// As of plan-B (issue #233) `InputEdit`s are NOT carried here — they are
-/// applied synchronously by the main thread via [`SyntaxLayer::apply_edits`]
-/// directly onto the shared retained tree before any parse request is
-/// queued. The worker also no longer runs the highlight / build-by-row /
-/// signs pipeline; the main thread's `query_viewport` does that on each
-/// render tick. The fields below carry the byte range / viewport metadata
-/// that the worker emits back in the `RenderOutput` signal so the app can
-/// route the "tree updated" notification to the correct cache + region.
-struct ParseRequest {
-    buffer_id: BufferId,
-    source: Arc<String>,
-    #[allow(dead_code)]
-    row_starts: Arc<Vec<usize>>,
-    #[allow(dead_code)]
-    viewport_byte_range: std::ops::Range<usize>,
-    viewport_top: usize,
-    viewport_height: usize,
-    #[allow(dead_code)]
-    row_count: usize,
-    dirty_gen: u64,
-    /// When `true` the worker drops its retained tree before parsing.
-    /// Used after `:e` reload / theme swap so the next parse is cold.
-    reset: bool,
-    kind: ParseKind,
-}
-
-/// Control + data messages the worker thread waits on.
-enum Msg {
-    /// Set / replace the highlighter for a buffer. `None` detaches.
-    SetLanguage(BufferId, Option<Arc<Grammar>>),
-    /// Remove all worker state for a buffer (highlighter, retained tree,
-    /// parse-cache key). Sent on buffer close.
-    Forget(BufferId),
-    /// Replace the theme. Style resolution happens on the worker.
-    SetTheme(Arc<dyn Theme + Send + Sync>),
-    /// A parse + render job. Coalesced — only the latest pending
-    /// `Parse` survives if the worker is busy.
-    Parse(ParseRequest),
-    /// Worker should exit. Sent on `SyntaxWorker::drop`.
-    Quit,
-}
-
-/// Maximum number of parse requests allowed in the queue at once.
-const PARSE_QUEUE_CAP: usize = 8;
-
-/// Shared slot the main thread drops new requests into.
-struct Pending {
-    /// FIFO of parse requests. Per-(buffer_id, kind) deduped: submitting a
-    /// request for buffer A + kind Viewport replaces any existing entry for
-    /// that pair rather than appending. Capped at [`PARSE_QUEUE_CAP`] total entries.
-    parse_queue: std::collections::VecDeque<ParseRequest>,
-    /// FIFO of control messages (SetLanguage, Forget, SetTheme, Quit).
-    controls: std::collections::VecDeque<Msg>,
-}
-
-impl Pending {
-    fn new() -> Self {
+impl Default for BufferClient {
+    fn default() -> Self {
         Self {
-            parse_queue: std::collections::VecDeque::new(),
-            controls: std::collections::VecDeque::new(),
+            has_language: false,
+            current_lang: None,
+            highlighter: None,
+            cache_dirty_gen: None,
+            cache_rows: 0..0,
+            cache_spans: Vec::new(),
+            cache_row_starts: None,
+            parsed_dirty_gen: None,
+            cache_signs: None,
         }
     }
+}
 
-    fn has_work(&self) -> bool {
-        !self.parse_queue.is_empty() || !self.controls.is_empty()
-    }
-
-    /// Enqueue a parse request with per-`(buffer_id, kind)` deduplication.
-    ///
-    /// - If a request for the same `(buffer_id, kind)` pair is already in
-    ///   the queue, replace it in-place (latest wins). Requests with the
-    ///   same buffer_id but different kinds (Viewport / Top / Bottom)
-    ///   coexist in the queue so all three regions can be pre-cached.
-    /// - If the queue is at capacity and there is no existing entry for
-    ///   this `(buffer_id, kind)`, evict the oldest entry before pushing.
-    ///
-    /// Edit deltas are no longer carried on the request (plan B / #233):
-    /// `SyntaxLayer::apply_edits` calls `tree.edit(InputEdit)` synchronously
-    /// against the shared retained tree before any submit, so a replaced
-    /// request can be wholesale-discarded without losing edit history.
-    fn push_parse(&mut self, req: ParseRequest) {
-        for slot in self.parse_queue.iter_mut() {
-            if slot.buffer_id == req.buffer_id && slot.kind == req.kind {
-                *slot = req;
-                return;
-            }
-        }
-        if self.parse_queue.len() >= PARSE_QUEUE_CAP {
-            self.parse_queue.pop_front();
-        }
-        self.parse_queue.push_back(req);
+impl BufferClient {
+    fn invalidate_cache(&mut self) {
+        self.cache_dirty_gen = None;
+        self.cache_rows = 0..0;
+        self.cache_spans.clear();
+        self.cache_row_starts = None;
+        self.parsed_dirty_gen = None;
+        self.cache_signs = None;
     }
 }
 
 // ---------------------------------------------------------------------------
-// SyntaxWorker — background thread
+// SyntaxLayer — main-thread, fully synchronous
 // ---------------------------------------------------------------------------
 
-/// Background worker that owns the `Highlighter` and the retained
-/// tree-sitter `Tree`. Communicates with the main thread via a
-/// `Mutex<Pending>` + `Condvar` for submits, and an mpsc channel for
-/// rendered output.
+/// Per-App syntax highlighting layer. Multiplexes per-buffer state.
+/// Fully synchronous — no background thread.
 ///
 /// # Examples
 ///
 /// ```no_run
 /// use std::sync::Arc;
-/// use hjkl_syntax::SyntaxWorker;
+/// use hjkl_syntax::SyntaxLayer;
 /// use hjkl_bonsai::DotFallbackTheme;
 /// use hjkl_lang::LanguageDirectory;
 ///
 /// let theme = Arc::new(DotFallbackTheme::dark());
 /// let dir = Arc::new(LanguageDirectory::new().unwrap());
-/// let worker = SyntaxWorker::spawn(theme, dir);
-/// drop(worker); // joins the thread
+/// let layer = SyntaxLayer::new(theme, dir);
 /// ```
-pub struct SyntaxWorker {
-    pending: Arc<(Mutex<Pending>, Condvar)>,
-    rx: std::sync::mpsc::Receiver<RenderOutput>,
-    /// Shared per-buffer pipeline state. Cloned to the worker thread at
-    /// spawn; cloned again to [`SyntaxLayer`] so main-thread sync queries
-    /// reach the same retained tree.
-    pub(crate) buffers: SharedBuffers,
-    handle: Option<JoinHandle<()>>,
+pub struct SyntaxLayer {
+    /// Shared grammar resolver.
+    pub directory: Arc<LanguageDirectory>,
+    theme: Arc<dyn Theme + Send + Sync>,
+    clients: HashMap<BufferId, BufferClient>,
+    pending_loads: Vec<PendingLoad>,
 }
 
-impl SyntaxWorker {
-    /// Spawn a fresh worker thread with the given theme and language directory.
-    pub fn spawn(theme: Arc<dyn Theme + Send + Sync>, directory: Arc<LanguageDirectory>) -> Self {
-        let pending = Arc::new((Mutex::new(Pending::new()), Condvar::new()));
-        let (tx, rx) = std::sync::mpsc::channel();
-        let buffers: SharedBuffers = Arc::new(Mutex::new(HashMap::new()));
-        let pending_for_thread = Arc::clone(&pending);
-        let buffers_for_thread = Arc::clone(&buffers);
-        let handle = thread::Builder::new()
-            .name("hjkl-syntax".into())
-            .spawn(move || {
-                worker_loop(pending_for_thread, buffers_for_thread, tx, theme, directory)
-            })
-            .expect("spawn syntax worker");
-        Self {
-            pending,
-            rx,
-            buffers,
-            handle: Some(handle),
-        }
-    }
-
-    /// Send a control message. Wakes the worker.
-    fn enqueue_control(&self, msg: Msg) {
-        let (lock, cvar) = &*self.pending;
-        let mut p = lock.lock().expect("syntax pending mutex poisoned");
-        p.controls.push_back(msg);
-        cvar.notify_one();
-    }
-
-    /// Set / replace the highlighter for a buffer. `None` detaches.
-    pub fn set_language(&self, id: BufferId, grammar: Option<Arc<Grammar>>) {
-        self.enqueue_control(Msg::SetLanguage(id, grammar));
-    }
-
-    /// Forget all worker state for a buffer (highlighter + tree).
-    /// Sent on buffer close.
-    pub fn forget(&self, id: BufferId) {
-        self.enqueue_control(Msg::Forget(id));
-    }
-
-    /// Replace the theme used for capture → style resolution.
-    pub fn set_theme(&self, theme: Arc<dyn Theme + Send + Sync>) {
-        self.enqueue_control(Msg::SetTheme(theme));
-    }
-
-    /// Submit a parse job. Per-`(buffer_id, kind)` deduplication: if a
-    /// request for the same pair is already pending it is replaced in-place.
-    /// Across different pairs the queue is FIFO. Returns immediately.
-    fn submit(&self, req: ParseRequest) {
-        let (lock, cvar) = &*self.pending;
-        let mut p = lock.lock().expect("syntax pending mutex poisoned");
-        p.push_parse(req);
-        cvar.notify_one();
-    }
-
-    /// Drain all available render results, returning the most recent
-    /// one. Earlier results are discarded — they'd just be overwritten
-    /// by the latest install anyway, and this keeps the install path
-    /// O(1) per frame regardless of backlog depth.
-    #[allow(dead_code)]
-    pub fn try_recv_latest(&self) -> Option<RenderOutput> {
-        let mut latest: Option<RenderOutput> = None;
-        while let Ok(out) = self.rx.try_recv() {
-            latest = Some(out);
-        }
-        latest
-    }
-
-    /// Drain all available render results, returning them all (one per
-    /// `(buffer_id, kind)` pair that completed). Unlike
-    /// [`Self::try_recv_latest`] this does not discard earlier results —
-    /// required so pre-warmed results for non-active buffers can be routed
-    /// to the right slot cache.
-    pub fn try_recv_all(&self) -> Vec<RenderOutput> {
-        let mut results = Vec::new();
-        while let Ok(out) = self.rx.try_recv() {
-            if let Some(existing) = results
-                .iter_mut()
-                .find(|r: &&mut RenderOutput| r.buffer_id == out.buffer_id && r.kind == out.kind)
-            {
-                *existing = out;
-            } else {
-                results.push(out);
-            }
-        }
-        results
-    }
-
-    /// Wait up to `timeout` for the next result, then drain anything
-    /// else that arrived after it and return the latest.
-    pub fn wait_for_latest(&self, timeout: std::time::Duration) -> Option<RenderOutput> {
-        let mut latest = self.rx.recv_timeout(timeout).ok();
-        while let Ok(out) = self.rx.try_recv() {
-            latest = Some(out);
-        }
-        latest
-    }
-
-    /// Wait up to `timeout` for the first result to arrive, then drain
-    /// every additional result already in the channel. Returns ALL
-    /// results in arrival order (latest per `(buffer_id, kind)` coalesced).
+impl SyntaxLayer {
+    /// Create a new layer with no buffers attached.
     ///
-    /// Unlike [`Self::wait_for_latest`] this does NOT discard earlier
-    /// results — required when pre-warming non-active buffers so both the
-    /// active buffer's result and pre-warm results reach their slot caches.
-    pub fn wait_then_recv_all(&self, timeout: std::time::Duration) -> Vec<RenderOutput> {
-        let mut results: Vec<RenderOutput> = Vec::new();
-        if let Ok(first) = self.rx.recv_timeout(timeout) {
-            results.push(first);
-        }
-        while let Ok(out) = self.rx.try_recv() {
-            if let Some(existing) = results
-                .iter_mut()
-                .find(|r: &&mut RenderOutput| r.buffer_id == out.buffer_id && r.kind == out.kind)
-            {
-                *existing = out;
-            } else {
-                results.push(out);
-            }
-        }
-        results
-    }
-}
-
-impl Drop for SyntaxWorker {
-    fn drop(&mut self) {
-        {
-            let (lock, cvar) = &*self.pending;
-            if let Ok(mut p) = lock.lock() {
-                p.controls.push_back(Msg::Quit);
-                cvar.notify_one();
-            }
-        }
-        if let Some(h) = self.handle.take() {
-            let _ = h.join();
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use hjkl_syntax::SyntaxLayer;
+    /// use hjkl_bonsai::DotFallbackTheme;
+    /// use hjkl_lang::LanguageDirectory;
+    ///
+    /// let theme = Arc::new(DotFallbackTheme::dark());
+    /// let dir = Arc::new(LanguageDirectory::new().unwrap());
+    /// let layer = SyntaxLayer::new(theme, dir);
+    /// ```
+    pub fn new(theme: Arc<dyn Theme + Send + Sync>, directory: Arc<LanguageDirectory>) -> Self {
+        Self {
+            directory,
+            theme,
+            clients: HashMap::new(),
+            pending_loads: Vec::new(),
         }
     }
-}
 
-// ---------------------------------------------------------------------------
-// Worker-side per-buffer state
-// ---------------------------------------------------------------------------
+    /// Borrow the shared language directory.
+    pub fn directory(&self) -> &Arc<LanguageDirectory> {
+        &self.directory
+    }
 
-/// Per-buffer state retained for the syntax pipeline. Shared between the
-/// background worker thread (parse + async highlight) and the main thread
-/// (sync `query_viewport`, sync `tree.edit` on each `ContentEdit` batch).
-///
-/// Each buffer's state is wrapped in its own `Arc<Mutex<_>>` so different
-/// buffers can be operated on concurrently — the only contention is between
-/// worker reparse + main-thread query on the SAME buffer.
-pub(crate) struct WorkerBufferState {
-    pub(crate) highlighter: Highlighter,
-    pub(crate) last_parsed_dirty_gen: Option<u64>,
-}
+    fn client_mut(&mut self, id: BufferId) -> &mut BufferClient {
+        self.clients.entry(id).or_default()
+    }
 
-/// Shared map of per-buffer pipeline state. Outer `Mutex` protects map
-/// mutation (add / remove); inner `Mutex` protects each buffer's state.
-/// Lookups clone the inner `Arc` and drop the outer lock immediately so
-/// only same-buffer ops contend.
-pub(crate) type SharedBuffers = Arc<Mutex<HashMap<BufferId, Arc<Mutex<WorkerBufferState>>>>>;
-
-/// Look up a buffer in [`SharedBuffers`] and run `f` against its locked
-/// state. Returns `None` if the buffer is not tracked.
-///
-/// Holds the outer (map) lock only long enough to clone the inner `Arc`,
-/// then drops it before taking the per-buffer lock — so worker + main do
-/// not serialise across different buffers.
-pub(crate) fn with_buffer<R>(
-    buffers: &SharedBuffers,
-    id: BufferId,
-    f: impl FnOnce(&mut WorkerBufferState) -> R,
-) -> Option<R> {
-    let cell = {
-        let map = buffers.lock().expect("syntax shared buffers poisoned");
-        map.get(&id).cloned()
-    };
-    let cell = cell?;
-    let mut guard = cell.lock().expect("per-buffer state mutex poisoned");
-    Some(f(&mut guard))
-}
-
-// ---------------------------------------------------------------------------
-// Worker loop
-// ---------------------------------------------------------------------------
-
-fn worker_loop(
-    pending: Arc<(Mutex<Pending>, Condvar)>,
-    buffers: SharedBuffers,
-    tx: std::sync::mpsc::Sender<RenderOutput>,
-    initial_theme: Arc<dyn Theme + Send + Sync>,
-    directory: Arc<LanguageDirectory>,
-) {
-    let mut theme: Arc<dyn Theme + Send + Sync> = initial_theme;
-    let marker_pass = CommentMarkerPass::new();
-    let hex_color_pass = HexColorPass::new();
-
-    loop {
-        let msg = {
-            let (lock, cvar) = &*pending;
-            let mut p = lock.lock().expect("syntax pending mutex poisoned");
-            while !p.has_work() {
-                p = cvar.wait(p).expect("syntax pending cvar poisoned");
+    /// Detect the language for `path` and attach a grammar.
+    ///
+    /// - `Ready`   — grammar cached; highlighter installed immediately.
+    /// - `Loading` — grammar compiling; renders as plain text until
+    ///   `poll_pending_loads` fires `LoadEvent::Ready`.
+    /// - `Unknown` — unrecognized extension; plain text only.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use std::path::Path;
+    /// use hjkl_syntax::{SyntaxLayer, SetLanguageOutcome};
+    /// use hjkl_bonsai::DotFallbackTheme;
+    /// use hjkl_lang::LanguageDirectory;
+    ///
+    /// let theme = Arc::new(DotFallbackTheme::dark());
+    /// let dir = Arc::new(LanguageDirectory::new().unwrap());
+    /// let mut layer = SyntaxLayer::new(theme, dir);
+    /// let outcome = layer.set_language_for_path(0, Path::new("a.zzz_not_real"));
+    /// assert!(!outcome.is_known());
+    /// ```
+    pub fn set_language_for_path(&mut self, id: BufferId, path: &Path) -> SetLanguageOutcome {
+        match self.directory.request_for_path(path) {
+            GrammarRequest::Cached(grammar) => {
+                self.attach_grammar(id, grammar.clone());
+                let c = self.client_mut(id);
+                c.current_lang = Some(grammar);
+                c.has_language = true;
+                SetLanguageOutcome::Ready
             }
-            // Drain controls first so SetLanguage / Forget / SetTheme
-            // that arrived alongside a Parse get applied before we run
-            // the parse with stale state.
-            if let Some(c) = p.controls.pop_front() {
-                c
-            } else {
-                Msg::Parse(
-                    p.parse_queue
-                        .pop_front()
-                        .expect("has_work() implies parse_queue non-empty"),
-                )
+            GrammarRequest::Loading { name, handle } => {
+                let c = self.client_mut(id);
+                c.current_lang = None;
+                c.has_language = false;
+                c.highlighter = None;
+                c.invalidate_cache();
+                self.pending_loads.push(PendingLoad {
+                    id,
+                    name: name.clone(),
+                    handle,
+                });
+                SetLanguageOutcome::Loading(name)
             }
-        };
-
-        match msg {
-            Msg::Quit => return,
-            Msg::SetLanguage(id, None) => {
-                let mut map = buffers.lock().expect("syntax shared buffers poisoned");
-                map.remove(&id);
-            }
-            Msg::SetLanguage(id, Some(grammar)) => {
-                let lang = grammar.name().to_string();
-                match Highlighter::new(grammar) {
-                    Ok(h) => {
-                        let state = WorkerBufferState {
-                            highlighter: h,
-                            last_parsed_dirty_gen: None,
-                        };
-                        let mut map = buffers.lock().expect("syntax shared buffers poisoned");
-                        map.insert(id, Arc::new(Mutex::new(state)));
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            buffer_id = id,
-                            language = %lang,
-                            error = %e,
-                            "failed to attach syntax highlighter"
-                        );
-                        let mut map = buffers.lock().expect("syntax shared buffers poisoned");
-                        map.remove(&id);
-                    }
-                }
-            }
-            Msg::Forget(id) => {
-                let mut map = buffers.lock().expect("syntax shared buffers poisoned");
-                map.remove(&id);
-            }
-            Msg::SetTheme(t) => {
-                theme = t;
-            }
-            Msg::Parse(req) => {
-                let _ = run_parse_and_emit(
-                    &buffers,
-                    &req,
-                    &marker_pass,
-                    &hex_color_pass,
-                    theme.as_ref(),
-                    &directory,
-                    &tx,
-                );
+            GrammarRequest::Unknown | _ => {
+                let c = self.client_mut(id);
+                c.current_lang = None;
+                c.has_language = false;
+                c.highlighter = None;
+                c.invalidate_cache();
+                SetLanguageOutcome::Unknown
             }
         }
     }
-}
 
-/// Worker-side parse + highlight pipeline. Locks the buffer's per-state
-/// mutex briefly to apply edits + parse + run the highlight query + collect
-/// diag signs, then drops the lock before sending. Returns `Some(())` on
-/// success, `None` if the buffer was not tracked (was forgotten between
-/// request submission and dequeue).
-///
-/// Plan-B (#233): the worker now does **only** `parse_initial` or
-/// `parse_incremental` against the shared retained tree. The full
-/// highlight pipeline (highlight query, marker pass, hex-color pass,
-/// build-by-row, diag signs) that used to run here is gone — the main
-/// thread's `SyntaxLayer::query_viewport` runs the same work
-/// synchronously on every render tick against the retained tree.
-/// Producing it on the worker too was just a wasted equal-`dirty_gen`
-/// overwrite that the install path's generation guard had to discard.
-///
-/// The result message still uses [`RenderOutput`] (channel + install
-/// shape unchanged) but carries an EMPTY `spans` / `signs` and acts
-/// purely as a "tree updated for (buffer, kind, dg)" signal so the
-/// app can trigger a fresh sync query on the new tree.
-fn run_parse_and_emit(
-    buffers: &SharedBuffers,
-    req: &ParseRequest,
-    _marker_pass: &CommentMarkerPass,
-    _hex_color_pass: &HexColorPass,
-    _theme: &dyn Theme,
-    directory: &LanguageDirectory,
-    tx: &std::sync::mpsc::Sender<RenderOutput>,
-) -> Option<()> {
-    use std::time::Instant;
-    let bytes = req.source.as_bytes();
-    let (perf, did_parse, changed_ranges) = with_buffer(buffers, req.buffer_id, |state| {
-        let h = &mut state.highlighter;
-        let mut perf = PerfBreakdown::default();
-        // Clone the current tree BEFORE the reset/parse so we can diff
-        // against the freshly-parsed tree below. Tree clones are cheap
-        // (Arc-shared internals). Capturing this on the reset path lets
-        // us emit `changed_ranges` for undo/redo too — without it the
-        // install_render_result fallback runs a full ~30ms viewport
-        // refresh on every undo/redo.
-        let pre_parse_tree = h.tree().cloned();
-        if req.reset {
-            h.reset();
-            state.last_parsed_dirty_gen = None;
-        }
-        let needs_parse = h.tree().is_none() || state.last_parsed_dirty_gen != Some(req.dirty_gen);
-        if !needs_parse {
-            return Some((perf, false, Vec::new()));
-        }
-        let t = Instant::now();
-        let was_initial = h.tree().is_none();
-        let changes: Vec<std::ops::Range<usize>> = if was_initial {
-            h.parse_initial(bytes);
-            // `parse_incremental_with_changes` would normally compute
-            // this for us, but on the reset path we just did
-            // `parse_initial` (no old tree visible inside the
-            // highlighter). Reach back to the pre-reset clone and diff
-            // against the post-parse tree directly.
-            match (pre_parse_tree.as_ref(), h.tree()) {
-                (Some(old), Some(new)) => old
-                    .changed_ranges(new)
-                    .map(|r| r.start_byte..r.end_byte)
-                    .collect(),
-                _ => Vec::new(),
+    /// Attach a grammar to a buffer, creating/replacing the Highlighter.
+    fn attach_grammar(&mut self, id: BufferId, grammar: Arc<Grammar>) {
+        let c = self.clients.entry(id).or_default();
+        c.invalidate_cache();
+        match Highlighter::new(grammar) {
+            Ok(h) => {
+                c.highlighter = Some(h);
             }
-        } else {
-            match h.parse_incremental_with_changes(bytes) {
-                Some(c) => c,
+            Err(e) => {
+                tracing::error!(buffer_id = id, error = %e, "failed to attach highlighter");
+                c.highlighter = None;
+            }
+        }
+    }
+
+    /// Poll all in-flight grammar loads. Call once per tick.
+    ///
+    /// Returns one `LoadEvent` per handle that resolved during this tick.
+    pub fn poll_pending_loads(&mut self) -> Vec<LoadEvent> {
+        let mut events = Vec::new();
+        let mut i = 0;
+        while i < self.pending_loads.len() {
+            match self.pending_loads[i].handle.try_recv() {
                 None => {
-                    tracing::debug!(
-                        target: "hjkl::profile",
-                        buffer_id = ?req.buffer_id,
-                        bytes_len = bytes.len(),
-                        "worker parse FAILED"
-                    );
-                    return None;
+                    i += 1;
+                }
+                Some(Ok(lib_path)) => {
+                    let name = self.pending_loads[i].name.clone();
+                    let bid = self.pending_loads[i].id;
+                    self.pending_loads.swap_remove(i);
+                    match self.directory.complete_load(&name, lib_path) {
+                        Ok(grammar) => {
+                            self.attach_grammar(bid, grammar.clone());
+                            let c = self.client_mut(bid);
+                            c.current_lang = Some(grammar);
+                            c.has_language = true;
+                            events.push(LoadEvent::Ready { id: bid, name });
+                        }
+                        Err(e) => {
+                            events.push(LoadEvent::Failed {
+                                id: bid,
+                                name,
+                                error: format!("{e:#}"),
+                            });
+                        }
+                    }
+                }
+                Some(Err(err)) => {
+                    let name = self.pending_loads[i].name.clone();
+                    let bid = self.pending_loads[i].id;
+                    self.pending_loads.swap_remove(i);
+                    events.push(LoadEvent::Failed {
+                        id: bid,
+                        name,
+                        error: err.to_string(),
+                    });
                 }
             }
-        };
-        perf.parse_us = t.elapsed().as_micros();
-        tracing::debug!(
-            target: "hjkl::profile",
-            buffer_id = ?req.buffer_id,
-            bytes_len = bytes.len(),
-            parse_us = perf.parse_us,
-            was_initial,
-            dg = req.dirty_gen,
-            kind = ?req.kind,
-            changed_count = changes.len(),
-            "worker parse done"
-        );
-        state.last_parsed_dirty_gen = Some(req.dirty_gen);
-        let _ = directory;
-        Some((perf, true, changes))
-    })??;
-
-    // Only emit the "tree updated" signal when we actually reparsed.
-    // Without this guard the worker fires an empty signal on every scroll
-    // tick (dg unchanged → `needs_parse=false`), which `install_render_result`
-    // then turns into a redundant sync `query_viewport` walk per scroll —
-    // visible as scroll lag at high event rates.
-    if !did_parse {
-        return Some(());
+        }
+        events
     }
 
-    let key = (req.dirty_gen, req.viewport_top, req.viewport_height);
-    let _ = tx.send(RenderOutput {
-        buffer_id: req.buffer_id,
-        spans: Vec::new(),
-        signs: Vec::new(),
-        key,
-        perf,
-        kind: req.kind,
-        changed_ranges,
-    });
-    Some(())
+    /// Drop all state for a buffer. Call on close.
+    pub fn forget(&mut self, id: BufferId) {
+        self.clients.remove(&id);
+    }
+
+    /// Swap the active theme. Next `render_viewport` call uses the new theme.
+    pub fn set_theme(&mut self, theme: Arc<dyn Theme + Send + Sync>) {
+        self.theme = theme;
+        // Invalidate all per-buffer caches so they repaint with the new theme.
+        for c in self.clients.values_mut() {
+            c.invalidate_cache();
+        }
+    }
+
+    /// Apply a batch of engine `ContentEdit`s to the buffer's retained tree
+    /// synchronously. The cache will be invalidated on the next `render_viewport`
+    /// call via dirty_gen mismatch.
+    ///
+    /// No-op when no grammar is attached.
+    pub fn apply_edits(&mut self, id: BufferId, edits: &[hjkl_engine::ContentEdit]) {
+        let c = match self.clients.get_mut(&id) {
+            Some(c) if c.has_language => c,
+            _ => return,
+        };
+        let h = match c.highlighter.as_mut() {
+            Some(h) => h,
+            None => return,
+        };
+        for e in edits {
+            h.edit(&InputEdit {
+                start_byte: e.start_byte,
+                old_end_byte: e.old_end_byte,
+                new_end_byte: e.new_end_byte,
+                start_position: Point {
+                    row: e.start_position.0 as usize,
+                    column: e.start_position.1 as usize,
+                },
+                old_end_position: Point {
+                    row: e.old_end_position.0 as usize,
+                    column: e.old_end_position.1 as usize,
+                },
+                new_end_position: Point {
+                    row: e.new_end_position.0 as usize,
+                    column: e.new_end_position.1 as usize,
+                },
+            });
+        }
+        // dirty_gen will advance — invalidate parse + row_starts + sign caches.
+        // cache_spans / cache_rows are dropped on dirty_gen mismatch in render_viewport.
+        c.parsed_dirty_gen = None;
+        c.cache_row_starts = None;
+        c.cache_signs = None;
+    }
+
+    /// Drop the buffer's retained tree. Next `render_viewport` reparses from scratch.
+    ///
+    /// Call on `:e!` / content reset.
+    pub fn reset(&mut self, id: BufferId) {
+        if let Some(c) = self.clients.get_mut(&id) {
+            if let Some(h) = c.highlighter.as_mut() {
+                h.reset();
+            }
+            c.invalidate_cache();
+        }
+    }
+
+    /// Render spans for the visible viewport. Fully synchronous.
+    ///
+    /// 1. Returns `None` when no grammar is attached or buffer exceeds
+    ///    `huge_file_threshold` lines.
+    /// 2. Clears the cache when `buffer.dirty_gen()` has advanced.
+    /// 3. Returns cached rows when the request is fully inside the cached range.
+    /// 4. Walks only rows outside the cache (extend prefix/suffix), splices into
+    ///    `cache_spans`, extends `cache_rows`.
+    pub fn render_viewport(
+        &mut self,
+        id: BufferId,
+        buffer: &impl Query,
+        viewport_top: usize,
+        viewport_height: usize,
+        huge_file_threshold: u32,
+    ) -> Option<RenderOutput> {
+        if buffer.line_count() >= huge_file_threshold {
+            return None;
+        }
+
+        let client = self.clients.get_mut(&id)?;
+        if !client.has_language {
+            return None;
+        }
+        let dg = buffer.dirty_gen();
+        let row_count = buffer.line_count() as usize;
+        if row_count == 0 || viewport_height == 0 {
+            return None;
+        }
+
+        let vp_top = viewport_top.min(row_count);
+        let vp_end = (vp_top + viewport_height).min(row_count);
+        if vp_end <= vp_top {
+            return None;
+        }
+
+        // Single dirty_gen invalidation point.
+        if client.cache_dirty_gen != Some(dg) {
+            client.invalidate_cache();
+        }
+
+        // Build source. We always need it for parse + highlight.
+        let source = buffer.content_joined();
+        let bytes = source.as_bytes();
+
+        // Get or build row_starts, cached per dirty_gen.
+        let row_starts: Arc<Vec<usize>> = if client
+            .cache_row_starts
+            .as_ref()
+            .is_some_and(|(g, _)| *g == dg)
+        {
+            Arc::clone(&client.cache_row_starts.as_ref().unwrap().1)
+        } else {
+            let mut rs: Vec<usize> = vec![0];
+            for (i, &b) in bytes.iter().enumerate() {
+                if b == b'\n' {
+                    rs.push(i + 1);
+                }
+            }
+            let arc = Arc::new(rs);
+            client.cache_row_starts = Some((dg, Arc::clone(&arc)));
+            arc
+        };
+
+        // Reparse only when needed.
+        let needs_reparse = client.parsed_dirty_gen != Some(dg);
+        {
+            let highlighter = client.highlighter.as_mut()?;
+            if highlighter.tree().is_none() {
+                highlighter.parse_initial(bytes);
+                if highlighter.tree().is_some() {
+                    client.parsed_dirty_gen = Some(dg);
+                }
+            } else if needs_reparse {
+                let _ = highlighter.parse_incremental_with_changes(bytes);
+                if highlighter.tree().is_some() {
+                    client.parsed_dirty_gen = Some(dg);
+                }
+            }
+        }
+
+        // Re-borrow after parse.
+        let client = self.clients.get_mut(&id)?;
+        let highlighter = client.highlighter.as_mut()?;
+
+        // If still no tree (parse failed), give up.
+        highlighter.tree()?;
+
+        let theme = self.theme.as_ref();
+        let directory = Arc::clone(&self.directory);
+
+        // Extend cache to cover [vp_top, vp_end).
+        if client.cache_rows.is_empty() {
+            // Case A: empty cache — walk full range.
+            client.cache_spans = walk_rows(
+                highlighter,
+                bytes,
+                &row_starts,
+                row_count,
+                vp_top,
+                vp_end,
+                theme,
+                &directory,
+            );
+            client.cache_rows = vp_top..vp_end;
+            client.cache_dirty_gen = Some(dg);
+        } else {
+            let cache_covers_overlap =
+                vp_top < client.cache_rows.end && vp_end > client.cache_rows.start;
+            if !cache_covers_overlap {
+                // Disjoint — just rebuild the whole viewport.
+                client.cache_spans = walk_rows(
+                    highlighter,
+                    bytes,
+                    &row_starts,
+                    row_count,
+                    vp_top,
+                    vp_end,
+                    theme,
+                    &directory,
+                );
+                client.cache_rows = vp_top..vp_end;
+            } else {
+                // Case B: extend prefix if needed.
+                if vp_top < client.cache_rows.start {
+                    let new_rows = walk_rows(
+                        highlighter,
+                        bytes,
+                        &row_starts,
+                        row_count,
+                        vp_top,
+                        client.cache_rows.start,
+                        theme,
+                        &directory,
+                    );
+                    let mut combined = new_rows;
+                    combined.append(&mut client.cache_spans);
+                    client.cache_spans = combined;
+                    client.cache_rows.start = vp_top;
+                }
+                // Case C: extend suffix if needed.
+                if vp_end > client.cache_rows.end {
+                    let new_rows = walk_rows(
+                        highlighter,
+                        bytes,
+                        &row_starts,
+                        row_count,
+                        client.cache_rows.end,
+                        vp_end,
+                        theme,
+                        &directory,
+                    );
+                    client.cache_spans.extend(new_rows);
+                    client.cache_rows.end = vp_end;
+                }
+            }
+            client.cache_dirty_gen = Some(dg);
+        }
+
+        // Slice the requested viewport from the cache.
+        let offset = vp_top - client.cache_rows.start;
+        let len = vp_end - vp_top;
+        let spans: Vec<Vec<(usize, usize, StyleSpec)>> =
+            client.cache_spans[offset..offset + len].to_vec();
+
+        // Get or build signs, cached per (dirty_gen, vp_top, vp_end).
+        let signs = if client
+            .cache_signs
+            .as_ref()
+            .is_some_and(|(g, t, e, _)| *g == dg && *t == vp_top && *e == vp_end)
+        {
+            client.cache_signs.as_ref().unwrap().3.clone()
+        } else {
+            let s = collect_diag_signs_range(highlighter, bytes, &row_starts, vp_top, vp_end);
+            client.cache_signs = Some((dg, vp_top, vp_end, s.clone()));
+            s
+        };
+
+        Some(RenderOutput {
+            buffer_id: id,
+            spans,
+            signs,
+            key: (dg, vp_top, viewport_height),
+            perf: PerfBreakdown::default(),
+        })
+    }
+
+    /// Resolve a path to its language name without loading a grammar.
+    pub fn name_for_path(&self, path: &Path) -> Option<String> {
+        self.directory.name_for_path(path)
+    }
+
+    /// Returns `true` if a client is tracked for the given buffer id.
+    #[doc(hidden)]
+    pub fn has_client(&self, id: BufferId) -> bool {
+        self.clients.contains_key(&id)
+    }
+
+    /// Dispatch a [`LoadEvent`] through a caller-supplied handler.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use hjkl_syntax::{LoadEvent, SyntaxLayer};
+    ///
+    /// let event = LoadEvent::Ready { id: 0, name: "rust".into() };
+    /// let mut got_ready = false;
+    /// let handled = SyntaxLayer::dispatch_load_event(&event, |ev| {
+    ///     use hjkl_syntax::LoadEventKind;
+    ///     match ev {
+    ///         LoadEventKind::Ready { id, name } => { got_ready = true; }
+    ///         LoadEventKind::Failed { .. } => {}
+    ///     }
+    /// });
+    /// assert!(handled);
+    /// assert!(got_ready);
+    /// ```
+    pub fn dispatch_load_event(
+        event: &LoadEvent,
+        mut handler: impl FnMut(LoadEventKind<'_>),
+    ) -> bool {
+        #[allow(unreachable_patterns)]
+        match event {
+            LoadEvent::Ready { id, name } => {
+                handler(LoadEventKind::Ready { id: *id, name });
+                true
+            }
+            LoadEvent::Failed { id, name, error } => {
+                handler(LoadEventKind::Failed {
+                    id: *id,
+                    name,
+                    error,
+                });
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: walk a row range against the retained tree
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn walk_rows(
+    highlighter: &mut Highlighter,
+    bytes: &[u8],
+    row_starts: &[usize],
+    row_count: usize,
+    seg_start: usize,
+    seg_end: usize,
+    theme: &dyn Theme,
+    directory: &Arc<LanguageDirectory>,
+) -> Vec<Vec<(usize, usize, StyleSpec)>> {
+    let bytes_len = bytes.len();
+    let byte_start = row_starts.get(seg_start).copied().unwrap_or(bytes_len);
+    let byte_end = row_starts
+        .get(seg_end)
+        .copied()
+        .unwrap_or(bytes_len)
+        .min(bytes_len)
+        .max(byte_start);
+
+    let mut flat_spans =
+        highlighter.highlight_range_with_injections(bytes, byte_start..byte_end, |name| {
+            directory.by_name(name)
+        });
+
+    let marker_pass = CommentMarkerPass::new();
+    marker_pass.apply(&mut flat_spans, bytes);
+    let hex_color_pass = HexColorPass::new();
+    hex_color_pass.apply_range(&mut flat_spans, bytes, byte_start..byte_end);
+
+    // build_by_row on the full row_count, then slice out the segment.
+    let full = build_by_row(&flat_spans, bytes, row_starts, row_count, theme);
+    full[seg_start..seg_end.min(full.len())].to_vec()
 }
 
 // ---------------------------------------------------------------------------
 // Helper: build per-row span table (renderer-agnostic StyleSpec output)
 // ---------------------------------------------------------------------------
 
-/// Resolve flat highlight spans into a per-row span table sized to
-/// `row_count`. Pulled out so the worker can call it in isolation and tests
-/// can exercise it without a running thread.
-///
-/// Output: `Vec<Vec<(byte_start, byte_end, StyleSpec)>>` indexed by row.
+/// Resolve flat highlight spans into a per-row span table sized to `row_count`.
 pub fn build_by_row(
     flat_spans: &[hjkl_bonsai::HighlightSpan],
     bytes: &[u8],
@@ -919,10 +857,6 @@ pub fn build_by_row(
     let mut by_row: Vec<Vec<(usize, usize, StyleSpec)>> = vec![Vec::new(); row_count];
 
     for span in flat_spans {
-        // Hex-color preview overlay: bypass the theme and build a
-        // StyleSpec directly from the metadata that HexColorPass
-        // attached. `hex_color` is intentionally NOT a theme key —
-        // the colour comes from the source literal itself.
         let hex_style: Option<StyleSpec> = if span.capture() == HEX_COLOR_CAPTURE {
             let bg = match span.metadata.get(HEX_BG_KEY) {
                 Some(MetaValue::Str(s)) => hjkl_theme::Color::from_hex_str(s).ok(),
@@ -988,15 +922,17 @@ pub fn build_by_row(
 // Helper: collect diagnostic signs
 // ---------------------------------------------------------------------------
 
-/// Collect diagnostic [`DiagSign`]s from tree-sitter ERROR / MISSING nodes
-/// intersecting the viewport, deduped to one per row.
-fn collect_diag_signs(
+fn collect_diag_signs_range(
     h: &mut Highlighter,
     bytes: &[u8],
-    viewport_byte_range: std::ops::Range<usize>,
     row_starts: &[usize],
+    vp_top: usize,
+    vp_end: usize,
 ) -> Vec<DiagSign> {
-    let errors = h.parse_errors_range(bytes, viewport_byte_range);
+    let bytes_len = bytes.len();
+    let byte_start = row_starts.get(vp_top).copied().unwrap_or(bytes_len);
+    let byte_end = row_starts.get(vp_end).copied().unwrap_or(bytes_len);
+    let errors = h.parse_errors_range(bytes, byte_start..byte_end);
     let mut signs: Vec<DiagSign> = Vec::new();
     let mut last_row: Option<usize> = None;
     for err in &errors {
@@ -1013,776 +949,6 @@ fn collect_diag_signs(
 }
 
 // ---------------------------------------------------------------------------
-// Per-buffer client state (main thread)
-// ---------------------------------------------------------------------------
-
-/// Per-buffer client-side state. One of these per open buffer in
-/// `SyntaxLayer.clients`. Mirrors the worker's `WorkerBufferState` but
-/// holds the source-cache + edit queue, which live on the main thread.
-#[derive(Default)]
-struct BufferClient {
-    has_language: bool,
-    current_lang: Option<Arc<Grammar>>,
-    cache: Option<RenderCache>,
-    pending_reset: bool,
-    last_submitted_dirty_gen: Option<u64>,
-}
-
-// ---------------------------------------------------------------------------
-// In-flight grammar load tracking
-// ---------------------------------------------------------------------------
-
-struct PendingLoad {
-    id: BufferId,
-    name: String,
-    handle: LoadHandle,
-}
-
-// ---------------------------------------------------------------------------
-// SyntaxLayer — main-thread facade
-// ---------------------------------------------------------------------------
-
-/// Per-App syntax highlighting layer. Multiplexes per-buffer state
-/// (helix-style): each open buffer carries its own retained tree
-/// (worker-side) plus source-cache and edit queue (here). One worker
-/// thread serves all buffers.
-///
-/// # Examples
-///
-/// ```no_run
-/// use std::sync::Arc;
-/// use hjkl_syntax::SyntaxLayer;
-/// use hjkl_bonsai::DotFallbackTheme;
-/// use hjkl_lang::LanguageDirectory;
-///
-/// let theme = Arc::new(DotFallbackTheme::dark());
-/// let dir = Arc::new(LanguageDirectory::new().unwrap());
-/// let layer = SyntaxLayer::new(theme, dir);
-/// ```
-pub struct SyntaxLayer {
-    /// Shared grammar resolver.
-    pub directory: Arc<LanguageDirectory>,
-    /// Active theme.
-    theme: Arc<dyn Theme + Send + Sync>,
-    worker: SyntaxWorker,
-    clients: HashMap<BufferId, BufferClient>,
-    pending_loads: Vec<PendingLoad>,
-    /// Per-grammar synchronous `Highlighter` cache used by [`Self::preview_render`].
-    preview_highlighters: Mutex<HashMap<String, Highlighter>>,
-    /// Last perf breakdown received via `take_all_results`. Updated on every
-    /// successful drain.
-    pub last_perf: PerfBreakdown,
-}
-
-impl SyntaxLayer {
-    /// Create a new layer with no buffers attached, the given theme, and
-    /// the given language directory.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::sync::Arc;
-    /// use hjkl_syntax::SyntaxLayer;
-    /// use hjkl_bonsai::DotFallbackTheme;
-    /// use hjkl_lang::LanguageDirectory;
-    ///
-    /// let theme = Arc::new(DotFallbackTheme::dark());
-    /// let dir = Arc::new(LanguageDirectory::new().unwrap());
-    /// let layer = SyntaxLayer::new(theme, dir);
-    /// ```
-    /// Borrow the shared language directory. Useful for cheap
-    /// path-to-language-name lookups (e.g. `name_for_path`) without
-    /// triggering any grammar load.
-    pub fn directory(&self) -> &Arc<LanguageDirectory> {
-        &self.directory
-    }
-
-    pub fn new(theme: Arc<dyn Theme + Send + Sync>, directory: Arc<LanguageDirectory>) -> Self {
-        let worker = SyntaxWorker::spawn(Arc::clone(&theme), Arc::clone(&directory));
-        Self {
-            directory,
-            theme,
-            worker,
-            clients: HashMap::new(),
-            pending_loads: Vec::new(),
-            preview_highlighters: Mutex::new(HashMap::new()),
-            last_perf: PerfBreakdown::default(),
-        }
-    }
-
-    fn client_mut(&mut self, id: BufferId) -> &mut BufferClient {
-        self.clients.entry(id).or_default()
-    }
-
-    /// Detect the language for `path` and ship it to the worker.
-    ///
-    /// Non-blocking: uses the async grammar loader so opening a file with an
-    /// uninstalled grammar no longer freezes the UI.
-    ///
-    /// - `Ready`   — grammar cached/found on disk; installed immediately.
-    /// - `Loading` — clone+compile kicked off; buffer renders as plain text
-    ///   until `poll_pending_loads` fires the companion `LoadEvent::Ready`.
-    /// - `Unknown` — unrecognized extension; plain text only.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::sync::Arc;
-    /// use std::path::Path;
-    /// use hjkl_syntax::{SyntaxLayer, SetLanguageOutcome};
-    /// use hjkl_bonsai::DotFallbackTheme;
-    /// use hjkl_lang::LanguageDirectory;
-    ///
-    /// let theme = Arc::new(DotFallbackTheme::dark());
-    /// let dir = Arc::new(LanguageDirectory::new().unwrap());
-    /// let mut layer = SyntaxLayer::new(theme, dir);
-    /// let outcome = layer.set_language_for_path(0, Path::new("a.zzz_not_real"));
-    /// assert!(!outcome.is_known());
-    /// ```
-    pub fn set_language_for_path(&mut self, id: BufferId, path: &Path) -> SetLanguageOutcome {
-        match self.directory.request_for_path(path) {
-            GrammarRequest::Cached(grammar) => {
-                self.worker.set_language(id, Some(grammar.clone()));
-                let c = self.client_mut(id);
-                c.current_lang = Some(grammar);
-                c.has_language = true;
-                SetLanguageOutcome::Ready
-            }
-            GrammarRequest::Loading { name, handle } => {
-                self.worker.set_language(id, None);
-                let c = self.client_mut(id);
-                c.current_lang = None;
-                c.has_language = false;
-                self.pending_loads.push(PendingLoad {
-                    id,
-                    name: name.clone(),
-                    handle,
-                });
-                SetLanguageOutcome::Loading(name)
-            }
-            GrammarRequest::Unknown => {
-                self.worker.set_language(id, None);
-                let c = self.client_mut(id);
-                c.current_lang = None;
-                c.has_language = false;
-                SetLanguageOutcome::Unknown
-            }
-            _ => {
-                // Future GrammarRequest variants — treat as Unknown.
-                self.worker.set_language(id, None);
-                let c = self.client_mut(id);
-                c.current_lang = None;
-                c.has_language = false;
-                SetLanguageOutcome::Unknown
-            }
-        }
-    }
-
-    /// Poll all in-flight grammar loads. Call this once per tick from the
-    /// main loop (alongside `take_all_results`) so completed loads install
-    /// immediately without waiting for the next file open.
-    ///
-    /// Returns one `LoadEvent` per handle that resolved during this tick.
-    /// Non-empty results should trigger a redraw and re-submit render.
-    pub fn poll_pending_loads(&mut self) -> Vec<LoadEvent> {
-        let mut events = Vec::new();
-        let mut i = 0;
-        while i < self.pending_loads.len() {
-            match self.pending_loads[i].handle.try_recv() {
-                None => {
-                    i += 1;
-                }
-                Some(Ok(lib_path)) => {
-                    let name = self.pending_loads[i].name.clone();
-                    let bid = self.pending_loads[i].id;
-                    self.pending_loads.swap_remove(i);
-                    match self.directory.complete_load(&name, lib_path) {
-                        Ok(grammar) => {
-                            self.worker.set_language(bid, Some(grammar.clone()));
-                            let c = self.client_mut(bid);
-                            c.current_lang = Some(grammar);
-                            c.has_language = true;
-                            events.push(LoadEvent::Ready { id: bid, name });
-                        }
-                        Err(e) => {
-                            events.push(LoadEvent::Failed {
-                                id: bid,
-                                name,
-                                error: format!("{e:#}"),
-                            });
-                        }
-                    }
-                }
-                Some(Err(err)) => {
-                    let name = self.pending_loads[i].name.clone();
-                    let bid = self.pending_loads[i].id;
-                    self.pending_loads.swap_remove(i);
-                    events.push(LoadEvent::Failed {
-                        id: bid,
-                        name,
-                        error: err.to_string(),
-                    });
-                }
-            }
-        }
-        events
-    }
-
-    /// Drop all state for a buffer. Call on close.
-    pub fn forget(&mut self, id: BufferId) {
-        self.clients.remove(&id);
-        self.worker.forget(id);
-    }
-
-    /// Swap the active theme. Next render call will use the new theme.
-    pub fn set_theme(&mut self, theme: Arc<dyn Theme + Send + Sync>) {
-        self.theme = Arc::clone(&theme);
-        self.worker.set_theme(theme);
-    }
-
-    /// Borrow the buffer's cached `(source, row_starts, line_count, dirty_gen)`
-    /// from the last [`Self::submit_render`] call, if any.
-    ///
-    /// `dirty_gen` is the buffer's generation at the time the cache was
-    /// built — callers compare it against the buffer's *current* generation
-    /// to decide whether to run a sync [`Self::query_viewport`] (cache is
-    /// up to date) or skip (cache is stale, throttled submit hasn't fired
-    /// the rebuild yet).
-    #[allow(clippy::type_complexity)]
-    pub fn cached_source(
-        &self,
-        id: BufferId,
-    ) -> Option<(Arc<String>, Arc<Vec<usize>>, usize, u64)> {
-        let c = self.clients.get(&id)?;
-        let rc = c.cache.as_ref()?;
-        Some((
-            Arc::clone(&rc.source),
-            Arc::clone(&rc.row_starts),
-            rc.line_count as usize,
-            rc.dirty_gen,
-        ))
-    }
-
-    /// Synchronous viewport highlight query against the **retained tree**
-    /// owned by the syntax worker.
-    ///
-    /// Unlike [`Self::submit_render`] (queues a parse + highlight on the
-    /// worker, result delivered later via [`Self::take_all_results`]), this
-    /// runs the highlight + marker + hex-color + diag-signs pipeline
-    /// synchronously on the calling thread using the worker's current
-    /// retained `tree_sitter::Tree`. No re-parse: the spans are extracted
-    /// against whatever tree the worker last produced.
-    ///
-    /// Returns `None` when:
-    /// - no grammar is attached to `id` yet (or it is still loading), or
-    /// - the worker has not produced its first parse for this buffer yet,
-    /// - the worker is currently parsing this buffer (lock would block —
-    ///   for now we wait; future revs may add a `try_*` variant).
-    ///
-    /// Intended use: render-time path on the main thread, so the visible
-    /// rows always paint against the freshest tree the layer has, even
-    /// while a follow-up parse is in flight. This is the foundation for
-    /// the bonsai cache redesign tracked at <https://github.com/kryptic-sh/hjkl/issues/233>.
-    #[allow(clippy::too_many_arguments)]
-    pub fn query_viewport(
-        &self,
-        id: BufferId,
-        source: &str,
-        row_starts: &[usize],
-        viewport_byte_range: std::ops::Range<usize>,
-        viewport_top: usize,
-        viewport_height: usize,
-        row_count: usize,
-        dirty_gen: u64,
-        kind: ParseKind,
-    ) -> Option<RenderOutput> {
-        use std::time::Instant;
-        let bytes = source.as_bytes();
-        let theme = self.theme.as_ref();
-        let directory = self.directory.clone();
-        with_buffer(&self.worker.buffers, id, |state| {
-            // No retained tree yet — caller should fall back to
-            // `preview_render` or wait for the worker's first delivery.
-            state.highlighter.tree()?;
-            let mut perf = PerfBreakdown::default();
-            let t = Instant::now();
-            let mut flat_spans = state.highlighter.highlight_range_with_injections(
-                bytes,
-                viewport_byte_range.clone(),
-                |name| directory.by_name(name),
-            );
-            perf.highlight_us = t.elapsed().as_micros();
-            let flat_span_count = flat_spans.len();
-
-            let t_marker = Instant::now();
-            let marker_pass = CommentMarkerPass::new();
-            marker_pass.apply(&mut flat_spans, bytes);
-            let marker_us = t_marker.elapsed().as_micros();
-
-            let t_hex = Instant::now();
-            // Scan only the viewport bytes for hex colors — full-document
-            // scan per keystroke was a ~200µs hit on 400-line files and
-            // grows with file size.
-            let hex_color_pass = HexColorPass::new();
-            hex_color_pass.apply_range(&mut flat_spans, bytes, viewport_byte_range.clone());
-            let hex_us = t_hex.elapsed().as_micros();
-
-            let t = Instant::now();
-            let by_row = build_by_row(&flat_spans, bytes, row_starts, row_count, theme);
-            perf.by_row_us = t.elapsed().as_micros();
-
-            let t = Instant::now();
-            let signs = collect_diag_signs(
-                &mut state.highlighter,
-                bytes,
-                viewport_byte_range,
-                row_starts,
-            );
-            perf.diag_us = t.elapsed().as_micros();
-
-            tracing::debug!(
-                target: "hjkl::profile",
-                ?kind,
-                highlight_us = perf.highlight_us,
-                marker_us,
-                hex_us,
-                by_row_us = perf.by_row_us,
-                diag_us = perf.diag_us,
-                row_count,
-                flat_span_count,
-                "query_viewport breakdown"
-            );
-
-            // `key.0` tags the result with the dirty_gen the caller
-            // built `source` for. Setting it to the *current* buffer
-            // dirty_gen tells the app-side merger that this cache is
-            // fully up to date (no row should be marked dirty against
-            // it). The retained tree was already edited synchronously
-            // via `apply_edits`, so byte positions align.
-            Some(RenderOutput {
-                buffer_id: id,
-                spans: by_row,
-                signs,
-                key: (dirty_gen, viewport_top, viewport_height),
-                perf,
-                kind,
-                changed_ranges: Vec::new(),
-            })
-        })
-        .flatten()
-    }
-
-    /// Synchronous viewport-only preview render. Builds a `String`
-    /// containing **only** the visible rows, parses it from scratch with a
-    /// one-shot `Highlighter`, runs `highlight_range` over the slice, and
-    /// returns a `RenderOutput` whose `spans` table is padded with empty rows
-    /// above the viewport so the install path indexes the right rows.
-    ///
-    /// Returns `None` when no language is attached or when the viewport is empty.
-    pub fn preview_render(
-        &self,
-        id: BufferId,
-        buffer: &impl Query,
-        viewport_top: usize,
-        viewport_height: usize,
-    ) -> Option<RenderOutput> {
-        let grammar = self.clients.get(&id).and_then(|c| c.current_lang.clone())?;
-        let row_count = buffer.line_count() as usize;
-        if row_count == 0 || viewport_height == 0 {
-            return None;
-        }
-        let vp_top = viewport_top.min(row_count);
-        let vp_end_row = (vp_top + viewport_height).min(row_count);
-        if vp_end_row <= vp_top {
-            return None;
-        }
-
-        let mut source = String::new();
-        for r in vp_top..vp_end_row {
-            if r > vp_top {
-                source.push('\n');
-            }
-            source.push_str(&buffer.line(r as u32));
-        }
-        let bytes = source.as_bytes();
-        let mut row_starts: Vec<usize> = vec![0];
-        for (i, &b) in bytes.iter().enumerate() {
-            if b == b'\n' {
-                row_starts.push(i + 1);
-            }
-        }
-        let local_row_count = vp_end_row - vp_top;
-
-        let grammar_name = grammar.name().to_string();
-        let mut cache = self.preview_highlighters.lock().ok()?;
-        let h = match cache.entry(grammar_name) {
-            std::collections::hash_map::Entry::Occupied(o) => {
-                let h = o.into_mut();
-                h.reset();
-                h
-            }
-            std::collections::hash_map::Entry::Vacant(v) => match Highlighter::new(grammar) {
-                Ok(h) => v.insert(h),
-                Err(_) => return None,
-            },
-        };
-        let mut flat_spans =
-            h.highlight_with_injections(bytes, |name| self.directory.by_name(name));
-        drop(cache);
-
-        let marker_pass = CommentMarkerPass::new();
-        marker_pass.apply(&mut flat_spans, bytes);
-        let hex_color_pass = HexColorPass::new();
-        hex_color_pass.apply(&mut flat_spans, bytes);
-
-        let local_by_row = build_by_row(
-            &flat_spans,
-            bytes,
-            &row_starts,
-            local_row_count,
-            self.theme.as_ref(),
-        );
-
-        let mut spans: Vec<Vec<(usize, usize, StyleSpec)>> = vec![Vec::new(); vp_top];
-        spans.extend(local_by_row);
-
-        Some(RenderOutput {
-            buffer_id: id,
-            spans,
-            signs: Vec::new(),
-            key: (buffer.dirty_gen(), viewport_top, viewport_height),
-            perf: PerfBreakdown::default(),
-            kind: ParseKind::Viewport,
-            changed_ranges: Vec::new(),
-        })
-    }
-
-    /// Drop this buffer's retained tree **synchronously** so the next
-    /// `query_viewport` returns `None` (caller falls back to the one-shot
-    /// `preview_render`) and the next `submit_render` runs a cold parse.
-    ///
-    /// Wired into the editor's `take_content_reset` signal: bulk replaces
-    /// (`:e!`, undo of a multi-line edit, snapshot restore) emit a reset
-    /// instead of incremental `ContentEdit`s, so the retained tree's
-    /// byte positions no longer correlate with the new source. Letting
-    /// `query_viewport` run against that stale tree paints garbled spans
-    /// for one frame; dropping it sync avoids that frame entirely.
-    pub fn reset(&mut self, id: BufferId) {
-        self.client_mut(id).pending_reset = true;
-        with_buffer(&self.worker.buffers, id, |state| {
-            state.highlighter.reset();
-            state.last_parsed_dirty_gen = None;
-        });
-    }
-
-    /// Apply a batch of engine `ContentEdit`s to the shared retained tree
-    /// **synchronously** so the tree's byte positions track the new source
-    /// before the next `submit_render` or `query_viewport` runs.
-    ///
-    /// Plan-B (issue #233): edits are NOT queued on the request anymore —
-    /// they go straight onto the tree via `tree.edit(InputEdit)`. The
-    /// per-buffer mutex briefly serialises with worker reparse on the same
-    /// buffer; that contention is the only cost. The benefit: the very
-    /// next sync `query_viewport` returns spans whose byte ranges align
-    /// with the post-edit source, eliminating the per-frame stale-tree
-    /// flash that the old "ship edits to worker" path produced.
-    ///
-    /// If the buffer's grammar has not loaded yet (or the worker hasn't
-    /// installed the `Highlighter` for this buffer in the shared map yet),
-    /// the call is a no-op — the buffer's first parse will run against the
-    /// then-current source so edit history before grammar load doesn't matter.
-    pub fn apply_edits(&mut self, id: BufferId, edits: &[hjkl_engine::ContentEdit]) {
-        let c = self.client_mut(id);
-        if !c.has_language {
-            return;
-        }
-        let input_edits: Vec<InputEdit> = edits
-            .iter()
-            .map(|e| InputEdit {
-                start_byte: e.start_byte,
-                old_end_byte: e.old_end_byte,
-                new_end_byte: e.new_end_byte,
-                start_position: Point {
-                    row: e.start_position.0 as usize,
-                    column: e.start_position.1 as usize,
-                },
-                old_end_position: Point {
-                    row: e.old_end_position.0 as usize,
-                    column: e.old_end_position.1 as usize,
-                },
-                new_end_position: Point {
-                    row: e.new_end_position.0 as usize,
-                    column: e.new_end_position.1 as usize,
-                },
-            })
-            .collect();
-        with_buffer(&self.worker.buffers, id, |state| {
-            for e in &input_edits {
-                state.highlighter.edit(e);
-            }
-        });
-    }
-
-    /// Build (or reuse) the cached `(source, row_starts)` for the
-    /// current buffer state and submit a parse + render job to the worker.
-    /// Returns immediately. Drain the result with [`Self::take_all_results`].
-    ///
-    /// `kind` tags the request so the App can route the result to the correct
-    /// per-slot cache field. Pass [`ParseKind::Viewport`] for normal
-    /// scroll-driven parses.
-    ///
-    /// Returns `None` and submits nothing when no language is attached.
-    /// Returns `Some(source_build_us)` when a request was submitted — `0`
-    /// means the cache was reused.
-    pub fn submit_render(
-        &mut self,
-        id: BufferId,
-        buffer: &impl Query,
-        viewport_top: usize,
-        viewport_height: usize,
-        kind: ParseKind,
-    ) -> Option<u128> {
-        use std::time::Instant;
-        let c = self.client_mut(id);
-        if !c.has_language {
-            return None;
-        }
-
-        let dg = buffer.dirty_gen();
-        let lb = buffer.len_bytes();
-        let lc = buffer.line_count();
-        let row_count = lc as usize;
-
-        // Rebuild source + row_starts only when the buffer has changed.
-        let needs_rebuild = match &c.cache {
-            Some(rc) => rc.dirty_gen != dg || rc.len_bytes != lb || rc.line_count != lc,
-            None => true,
-        };
-        let mut source_build_us = 0u128;
-        if needs_rebuild {
-            let t = Instant::now();
-            // Share the joined source `Arc` with all other per-tick
-            // consumers (LSP notify, git signature, dirty hash) via
-            // `Buffer::content_joined`. The buffer caches against
-            // `dirty_gen` — first call this tick builds it, the rest
-            // are O(1) `Arc::clone`.
-            let source = buffer.content_joined();
-            let mut row_starts: Vec<usize> = vec![0];
-            for (i, &b) in source.as_bytes().iter().enumerate() {
-                if b == b'\n' {
-                    row_starts.push(i + 1);
-                }
-            }
-            c.cache = Some(RenderCache {
-                dirty_gen: dg,
-                len_bytes: lb,
-                line_count: lc,
-                source,
-                row_starts: Arc::new(row_starts),
-            });
-            source_build_us = t.elapsed().as_micros();
-        }
-        let cache = c.cache.as_ref().expect("cache populated above");
-
-        let bytes_len = cache.source.len();
-        let vp_start = buffer.byte_of_row(viewport_top);
-        let vp_end_row = viewport_top + viewport_height + 1;
-        let vp_end = buffer.byte_of_row(vp_end_row).min(bytes_len);
-        let vp_end = vp_end.max(vp_start);
-
-        let reset = std::mem::replace(&mut c.pending_reset, false);
-        c.last_submitted_dirty_gen = Some(dg);
-        let source_arc = Arc::clone(&cache.source);
-        let row_starts_arc = Arc::clone(&cache.row_starts);
-
-        self.worker.submit(ParseRequest {
-            buffer_id: id,
-            source: source_arc,
-            row_starts: row_starts_arc,
-            viewport_byte_range: vp_start..vp_end,
-            viewport_top,
-            viewport_height,
-            row_count,
-            dirty_gen: dg,
-            reset,
-            kind,
-        });
-
-        Some(source_build_us)
-    }
-
-    /// Drain the most recent render result the worker has produced (if any).
-    /// Older results are discarded — only the latest matters for install.
-    /// Updates `last_perf` as a side effect.
-    ///
-    /// Kept for use in perf-smoke tests; production code drains via
-    /// [`Self::take_all_results`] so multi-buffer results are routed.
-    #[allow(dead_code)]
-    pub fn take_result(&mut self) -> Option<RenderOutput> {
-        let out = self.worker.try_recv_latest()?;
-        self.last_perf = out.perf;
-        Some(out)
-    }
-
-    /// Drain all render results the worker has produced since the last drain
-    /// (one per `(buffer_id, kind)` that completed). Updates `last_perf` from
-    /// the last result if any are present.
-    pub fn take_all_results(&mut self) -> Vec<RenderOutput> {
-        let results = self.worker.try_recv_all();
-        if let Some(last) = results.last() {
-            self.last_perf = last.perf;
-        }
-        results
-    }
-
-    /// Block up to `timeout` for the worker's next result, then drain any
-    /// others that arrived after it.
-    pub fn wait_result(&mut self, timeout: std::time::Duration) -> Option<RenderOutput> {
-        let out = self.worker.wait_for_latest(timeout)?;
-        self.last_perf = out.perf;
-        Some(out)
-    }
-
-    /// Block up to `timeout` for the first result, then drain ALL available
-    /// results in arrival order (per-`(buffer_id, kind)` coalesced). Used for
-    /// big-jump paths that submit the active buffer's parse AND pre-warms for
-    /// other open buffers in the same tick.
-    pub fn wait_all_results(&mut self, timeout: std::time::Duration) -> Vec<RenderOutput> {
-        let results = self.worker.wait_then_recv_all(timeout);
-        if let Some(last) = results.last() {
-            self.last_perf = last.perf;
-        }
-        results
-    }
-
-    /// Synchronously drain the next result, blocking up to `timeout`.
-    /// Returns `None` on timeout. Used at startup so the very first frame
-    /// can paint with highlights when the worker is fast enough.
-    pub fn wait_for_initial_result(
-        &mut self,
-        timeout: std::time::Duration,
-    ) -> Option<RenderOutput> {
-        self.wait_result(timeout)
-    }
-
-    /// Test-only alias for [`Self::wait_for_initial_result`].
-    #[cfg(test)]
-    pub fn wait_for_result(&mut self, timeout: std::time::Duration) -> Option<RenderOutput> {
-        self.wait_for_initial_result(timeout)
-    }
-
-    /// Returns `true` if a client is tracked for the given buffer id.
-    /// Exposed for tests in consumer crates that wrap `SyntaxLayer`.
-    #[doc(hidden)]
-    pub fn has_client(&self, id: BufferId) -> bool {
-        self.clients.contains_key(&id)
-    }
-
-    /// Returns the `pending_reset` flag for the given buffer id, or `false`
-    /// if no client is tracked.
-    /// Exposed for tests in consumer crates that wrap `SyntaxLayer`.
-    #[doc(hidden)]
-    pub fn client_pending_reset(&self, id: BufferId) -> bool {
-        self.clients
-            .get(&id)
-            .map(|c| c.pending_reset)
-            .unwrap_or(false)
-    }
-
-    /// Dispatch a [`LoadEvent`] through a caller-supplied handler.
-    ///
-    /// The handler receives each known variant as an exhaustive inner enum so
-    /// consumers never need a `_ => {}` wildcard arm for `LoadEvent`'s
-    /// `#[non_exhaustive]` restriction.  Unknown future variants are silently
-    /// ignored (this method is updated when new variants land).
-    ///
-    /// Returns `true` when the event was dispatched to a known variant,
-    /// `false` when it was an unknown future variant and the handler was not
-    /// called.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use hjkl_syntax::{LoadEvent, SyntaxLayer};
-    ///
-    /// let event = LoadEvent::Ready { id: 0, name: "rust".into() };
-    /// let mut got_ready = false;
-    /// let handled = SyntaxLayer::dispatch_load_event(&event, |ev| {
-    ///     use hjkl_syntax::LoadEventKind;
-    ///     match ev {
-    ///         LoadEventKind::Ready { id, name } => { got_ready = true; }
-    ///         LoadEventKind::Failed { .. } => {}
-    ///     }
-    /// });
-    /// assert!(handled);
-    /// assert!(got_ready);
-    /// ```
-    pub fn dispatch_load_event(
-        event: &LoadEvent,
-        mut handler: impl FnMut(LoadEventKind<'_>),
-    ) -> bool {
-        // `#[allow(unreachable_patterns)]` because from inside this crate all
-        // LoadEvent variants are known; the wildcard exists so this helper
-        // stays future-proof for external consumers when new variants land.
-        #[allow(unreachable_patterns)]
-        match event {
-            LoadEvent::Ready { id, name } => {
-                handler(LoadEventKind::Ready { id: *id, name });
-                true
-            }
-            LoadEvent::Failed { id, name, error } => {
-                handler(LoadEventKind::Failed {
-                    id: *id,
-                    name,
-                    error,
-                });
-                true
-            }
-            // Unknown future variant — ignore gracefully.
-            _ => false,
-        }
-    }
-
-    /// Dispatch a [`ParseKind`] value through a caller-supplied handler.
-    ///
-    /// Eliminates `_ => {}` wildcards in consumer match arms by providing an
-    /// exhaustive inner enum.  Unknown future variants fall back to the
-    /// `ParseKind::Viewport` path (conservative: treat unknown as viewport).
-    ///
-    /// Returns `true` for known variants, `false` for unknown ones (and calls
-    /// the handler with `ParseKindKind::Viewport` as the fallback).
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use hjkl_syntax::{ParseKind, ParseKindKind, SyntaxLayer};
-    ///
-    /// let known = SyntaxLayer::dispatch_parse_kind(ParseKind::Viewport, |k| {
-    ///     assert_eq!(k, ParseKindKind::Viewport);
-    /// });
-    /// assert!(known);
-    /// ```
-    pub fn dispatch_parse_kind(kind: ParseKind, mut handler: impl FnMut(ParseKindKind)) -> bool {
-        // `#[allow(unreachable_patterns)]` because from inside this crate all
-        // ParseKind variants are known; the wildcard exists so this helper
-        // stays future-proof for external consumers when new variants land.
-        #[allow(unreachable_patterns)]
-        match kind {
-            ParseKind::Viewport => {
-                handler(ParseKindKind::Viewport);
-                true
-            }
-            // Unknown future variant — fall back to Viewport so the caller
-            // still gets a sensible route.
-            _ => {
-                handler(ParseKindKind::Viewport);
-                false
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Factory helpers
 // ---------------------------------------------------------------------------
 
@@ -1795,7 +961,6 @@ pub fn layer_with_theme(
 }
 
 /// Build a `SyntaxLayer` with hjkl-bonsai's bundled dark theme.
-/// Used by tests; the production app constructs via [`layer_with_theme`].
 #[cfg(test)]
 pub fn default_layer() -> SyntaxLayer {
     let directory = Arc::new(LanguageDirectory::new().expect("language directory"));
@@ -1811,26 +976,8 @@ mod tests {
     use super::*;
     use hjkl_buffer::Buffer;
     use std::path::Path;
-    use std::time::Duration;
-
-    fn submit_and_wait(
-        layer: &mut SyntaxLayer,
-        buf: &Buffer,
-        top: usize,
-        height: usize,
-    ) -> Option<RenderOutput> {
-        layer.submit_render(TID, buf, top, height, ParseKind::Viewport)?;
-        layer.wait_for_result(Duration::from_secs(5))
-    }
 
     const TID: BufferId = 0;
-
-    // --- ParseKind ---
-
-    #[test]
-    fn parse_kind_viewport_equals_itself() {
-        assert_eq!(ParseKind::Viewport, ParseKind::Viewport);
-    }
 
     // --- DiagSign ---
 
@@ -1881,10 +1028,8 @@ mod tests {
             vec![DiagSign::new(0, 'E', 100)],
             (7, 0, 30),
             PerfBreakdown::new(),
-            ParseKind::Viewport,
         );
         assert_eq!(out.buffer_id, 99);
-        assert_eq!(out.kind, ParseKind::Viewport);
         assert_eq!(out.key, (7, 0, 30));
         assert_eq!(out.signs.len(), 1);
     }
@@ -1897,30 +1042,8 @@ mod tests {
             vec![],
             (1, 0, 10),
             PerfBreakdown::default(),
-            ParseKind::Viewport,
         );
         let b = a.clone();
-        assert_eq!(a, b);
-    }
-
-    #[test]
-    fn render_output_partial_eq_same_kind() {
-        let a = RenderOutput::new(
-            0,
-            vec![],
-            vec![],
-            (0, 0, 10),
-            PerfBreakdown::default(),
-            ParseKind::Viewport,
-        );
-        let b = RenderOutput::new(
-            0,
-            vec![],
-            vec![],
-            (0, 0, 10),
-            PerfBreakdown::default(),
-            ParseKind::Viewport,
-        );
         assert_eq!(a, b);
     }
 
@@ -1940,9 +1063,6 @@ mod tests {
         assert!(by_row[1].is_empty());
     }
 
-    /// `hex_color` capture spans must build a StyleSpec from their
-    /// metadata (`hex.bg` / `hex.fg`) instead of going through the
-    /// theme — that's the whole point of the inline-preview overlay.
     #[test]
     fn build_by_row_hex_color_uses_metadata_colors() {
         let bytes = b"--accent: #bb9af7;";
@@ -1970,9 +1090,6 @@ mod tests {
         assert_eq!((fg.r, fg.g, fg.b), (0xff, 0xff, 0xff));
     }
 
-    /// `hex_color` spans without metadata fall back to skipping (no
-    /// theme key registered) instead of panicking — defensive guard
-    /// against a future caller that emits the capture without metadata.
     #[test]
     fn build_by_row_hex_color_without_metadata_skips() {
         let span = hjkl_bonsai::HighlightSpan {
@@ -1985,78 +1102,10 @@ mod tests {
         assert!(by_row[0].is_empty());
     }
 
-    // --- Pending queue deduplication ---
-
-    #[test]
-    fn pending_push_parse_replaces_same_buffer_kind() {
-        let mut p = Pending::new();
-        let make_req = |kind: ParseKind, dirty_gen: u64| ParseRequest {
-            buffer_id: 0,
-            source: Arc::new(String::new()),
-            row_starts: Arc::new(vec![]),
-            viewport_byte_range: 0..0,
-            viewport_top: 0,
-            viewport_height: 10,
-            row_count: 0,
-            dirty_gen,
-            reset: false,
-            kind,
-        };
-        p.push_parse(make_req(ParseKind::Viewport, 1));
-        p.push_parse(make_req(ParseKind::Viewport, 2));
-        // Same (buffer_id=0, kind=Viewport) — should replace, not append.
-        assert_eq!(p.parse_queue.len(), 1);
-        assert_eq!(p.parse_queue[0].dirty_gen, 2);
-    }
-
-    #[test]
-    fn pending_push_parse_different_buffers_coexist() {
-        let mut p = Pending::new();
-        let make_req = |buffer_id: BufferId| ParseRequest {
-            buffer_id,
-            source: Arc::new(String::new()),
-            row_starts: Arc::new(vec![]),
-            viewport_byte_range: 0..0,
-            viewport_top: 0,
-            viewport_height: 10,
-            row_count: 0,
-            dirty_gen: 1,
-            reset: false,
-            kind: ParseKind::Viewport,
-        };
-        p.push_parse(make_req(0));
-        p.push_parse(make_req(1));
-        p.push_parse(make_req(2));
-        // Different buffer ids must coexist in the queue.
-        assert_eq!(p.parse_queue.len(), 3);
-    }
-
-    #[test]
-    fn pending_push_parse_evicts_oldest_at_cap() {
-        let mut p = Pending::new();
-        // Fill past capacity with distinct (buffer_id, kind) pairs.
-        for i in 0..(PARSE_QUEUE_CAP + 2) {
-            p.push_parse(ParseRequest {
-                buffer_id: i as BufferId,
-                source: Arc::new(String::new()),
-                row_starts: Arc::new(vec![]),
-                viewport_byte_range: 0..0,
-                viewport_top: 0,
-                viewport_height: 10,
-                row_count: 0,
-                dirty_gen: i as u64,
-                reset: false,
-                kind: ParseKind::Viewport,
-            });
-        }
-        // Queue must not grow past cap.
-        assert!(p.parse_queue.len() <= PARSE_QUEUE_CAP);
-    }
-
     // --- SyntaxLayer basics (no network required) ---
 
     #[test]
-    fn submit_with_no_language_returns_none() {
+    fn render_viewport_with_no_language_returns_none() {
         let buf = Buffer::from_str("hello world");
         let mut layer = default_layer();
         assert!(
@@ -2064,11 +1113,7 @@ mod tests {
                 .set_language_for_path(TID, Path::new("a.unknownext"))
                 .is_known()
         );
-        assert!(
-            layer
-                .submit_render(TID, &buf, 0, 10, ParseKind::Viewport)
-                .is_none()
-        );
+        assert!(layer.render_viewport(TID, &buf, 0, 10, u32::MAX).is_none());
     }
 
     #[test]
@@ -2083,16 +1128,7 @@ mod tests {
             new_end_position: (0, 1),
         }];
         layer.apply_edits(TID, &edits);
-        // No grammar attached → call must be a no-op (no panic, no shared
-        // state mutation). The buffer is also absent from the worker's
-        // shared map.
-        assert!(layer.worker.buffers.lock().unwrap().get(&TID).is_none());
-    }
-
-    #[test]
-    fn worker_handles_quit_cleanly() {
-        let layer = default_layer();
-        drop(layer);
+        // No grammar attached → call must be a no-op (no panic).
     }
 
     #[test]
@@ -2116,18 +1152,18 @@ mod tests {
     #[test]
     fn forget_removes_client_state() {
         let mut layer = default_layer();
-        // Trigger client entry creation.
         layer.set_language_for_path(TID, Path::new("a.zzz_unknown"));
-        // Even if no client was inserted (Unknown path), forget must not panic.
         layer.forget(TID);
         assert!(!layer.clients.contains_key(&TID));
     }
 
     #[test]
-    fn take_all_results_empty_when_nothing_submitted() {
+    fn huge_file_returns_none() {
+        let buf = Buffer::from_str("fn main() {}");
         let mut layer = default_layer();
-        let results = layer.take_all_results();
-        assert!(results.is_empty());
+        // Language set but file threshold = 1 line (buffer has 1 line → over threshold).
+        // threshold = 0 means every file is "huge".
+        assert!(layer.render_viewport(TID, &buf, 0, 10, 0).is_none());
     }
 
     // --- Network-dependent tests (grammar needed) ---
@@ -2142,8 +1178,9 @@ mod tests {
                 .set_language_for_path(TID, Path::new("a.rs"))
                 .is_known()
         );
-        let out = submit_and_wait(&mut layer, &buf, 0, 10).expect("worker output");
-        assert_eq!(out.spans.len(), buf.row_count());
+        let out = layer
+            .render_viewport(TID, &buf, 0, 10, u32::MAX)
+            .expect("render output");
         assert!(
             out.spans.iter().any(|r| !r.is_empty()),
             "expected at least one styled span"
@@ -2152,34 +1189,11 @@ mod tests {
 
     #[test]
     #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn first_load_highlights_entire_viewport() {
-        let mut content = String::new();
-        for i in 0..50 {
-            content.push_str(&format!("fn f{i}() {{ let x = {i}; }}\n"));
-        }
-        let buf = Buffer::from_str(content.strip_suffix('\n').unwrap_or(&content));
-        let mut layer = default_layer();
-        assert!(
-            layer
-                .set_language_for_path(TID, Path::new("a.rs"))
-                .is_known()
-        );
-        let out = submit_and_wait(&mut layer, &buf, 0, 30).unwrap();
-        for (r, row) in out.spans.iter().take(30).enumerate() {
-            assert!(
-                !row.is_empty(),
-                "row {r} has no highlight spans on first load"
-            );
-        }
-    }
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
     fn diagnostics_emit_sign_for_syntax_error() {
         let buf = Buffer::from_str("fn main() {\nlet x = ;\n}\n");
         let mut layer = default_layer();
         layer.set_language_for_path(TID, Path::new("a.rs"));
-        let out = submit_and_wait(&mut layer, &buf, 0, 10).unwrap();
+        let out = layer.render_viewport(TID, &buf, 0, 10, u32::MAX).unwrap();
         assert!(
             !out.signs.is_empty(),
             "expected at least one diagnostic sign for `let x = ;`"
@@ -2197,7 +1211,7 @@ mod tests {
         let pre = Buffer::from_str("fn main() { let x = 1; }");
         let mut layer = default_layer();
         layer.set_language_for_path(TID, Path::new("a.rs"));
-        let _ = submit_and_wait(&mut layer, &pre, 0, 10).unwrap();
+        let _ = layer.render_viewport(TID, &pre, 0, 10, u32::MAX).unwrap();
         layer.apply_edits(
             TID,
             &[hjkl_engine::ContentEdit {
@@ -2210,26 +1224,13 @@ mod tests {
             }],
         );
         let post = Buffer::from_str("fn Ymain() { let x = 1; }");
-        let inc = submit_and_wait(&mut layer, &post, 0, 10).unwrap();
+        let inc = layer.render_viewport(TID, &post, 0, 10, u32::MAX).unwrap();
         let mut cold_layer = default_layer();
         cold_layer.set_language_for_path(TID, Path::new("a.rs"));
-        let cold = submit_and_wait(&mut cold_layer, &post, 0, 10).unwrap();
+        let cold = cold_layer
+            .render_viewport(TID, &post, 0, 10, u32::MAX)
+            .unwrap();
         assert_eq!(inc.spans, cold.spans);
-    }
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn reset_pending_request_is_consumed_once() {
-        let buf = Buffer::from_str("fn main() {}");
-        let mut layer = default_layer();
-        layer.set_language_for_path(TID, Path::new("a.rs"));
-        layer.reset(TID);
-        assert!(layer.clients.get(&TID).unwrap().pending_reset);
-        let _ = submit_and_wait(&mut layer, &buf, 0, 10).unwrap();
-        assert!(
-            !layer.clients.get(&TID).unwrap().pending_reset,
-            "pending_reset should clear after submit"
-        );
     }
 
     #[test]
@@ -2238,58 +1239,9 @@ mod tests {
         let buf = Buffer::from_str("fn main() {}");
         let mut layer = default_layer();
         layer.set_language_for_path(TID, Path::new("a.rs"));
-        let _ = submit_and_wait(&mut layer, &buf, 0, 10).unwrap();
+        let _ = layer.render_viewport(TID, &buf, 0, 10, u32::MAX).unwrap();
         assert!(layer.clients.contains_key(&TID));
         layer.forget(TID);
         assert!(!layer.clients.contains_key(&TID));
-    }
-}
-
-#[cfg(test)]
-mod perf_smoke {
-    use super::*;
-    use hjkl_buffer::Buffer;
-    use std::path::Path;
-    use std::time::{Duration, Instant};
-
-    #[test]
-    #[ignore = "network + compiler: needs tree-sitter-rust grammar"]
-    fn big_rs_smoke() {
-        let path = Path::new("/tmp/big.rs");
-        if !path.exists() {
-            eprintln!("/tmp/big.rs not present; skipping perf smoke");
-            return;
-        }
-        let content = std::fs::read_to_string(path).unwrap();
-        let buf = Buffer::from_str(content.strip_suffix('\n').unwrap_or(&content));
-        let mut layer = default_layer();
-        const TID: BufferId = 0;
-        assert!(layer.set_language_for_path(TID, path).is_known());
-
-        let t0 = Instant::now();
-        layer.submit_render(TID, &buf, 0, 50, ParseKind::Viewport);
-        let main_t = t0.elapsed();
-        let out = layer.wait_for_result(Duration::from_secs(10));
-        eprintln!(
-            "first submit_render main-thread: {:?}, worker turnaround total: {:?}",
-            main_t,
-            t0.elapsed()
-        );
-        assert!(out.is_some(), "first parse should produce output");
-
-        let t0 = Instant::now();
-        let mut main_total = Duration::ZERO;
-        for top in 0..100 {
-            let s = Instant::now();
-            layer.submit_render(TID, &buf, top * 100, 50, ParseKind::Viewport);
-            main_total += s.elapsed();
-        }
-        while layer.take_result().is_some() {}
-        eprintln!(
-            "100 viewport scrolls: total wall {:?}, main-thread total {:?} (avg {:?}/submit)",
-            t0.elapsed(),
-            main_total,
-            main_total / 100
-        );
     }
 }


### PR DESCRIPTION
## Summary

- **Drops the async syntax worker.** \`SyntaxLayer\` parses and queries on the main thread with a per-row scroll-delta cache (\`cache_rows\`/\`cache_spans\`/\`cache_row_starts\`/\`cache_signs\`/\`parsed_dirty_gen\`, all keyed by \`dirty_gen\`). Removes \`SyntaxWorker\`, channels, \`SharedBuffers\`, the cross-gen \`RenderOutput\` cache, \`dirty_rows_log\`, \`installed_rows\`, \`last_recompute_key\` throttling, and \`pending_recompute\` deferral. Initial parse is gated by \`huge_file_threshold\`.
- **search_count cached** per \`(buffer_id, dirty_gen, cursor, pattern)\`. Was 50%+ of CPU on big-buffer + /-search renders because it did two full \`Buffer::lines\` clones per frame. Miss path now uses \`content_joined\` (cached \`Arc<String>\`) — zero per-line allocs.
- **\`preview_render\` removed.** Was 14.6% CPU because every buffer-switch / file-open / picker / :e site called it immediately followed by \`render_viewport\` doing the same work twice. Sync \`render_viewport\` replaces it everywhere.
- **Save path cache reuse.** \`:w\` was calling \`Buffer::lines().join(\"\\\\n\")\`, re-cloning every line. Now reuses the same \`Arc<String>\` from \`content_joined\` shared with LSP / git / syntax / signature paths, and writes body + trailing newline in two pieces (no full-buffer clone for \`\\n\` append).
- **\`{count}p\` cursor fix.** Linewise \`{count}p\` was landing the cursor on row+count (last pasted line); vim leaves it on row+1 (first pasted line). \`P\` (before) and charwise paths unchanged.

## Test plan

- [x] \`cargo test --workspace\` (681 app + 191 engine + 28 syntax + 92 bonsai + 16 oracle pass; 1 unrelated anvil-installer flake recovers on rerun)
- [x] \`cargo clippy --workspace --tests\` clean
- [x] \`cargo fmt --all\` clean
- [x] New regression tests:
  - \`apps/hjkl/src/app/tests/marks_registers.rs\`: \`count_p_pastes_register_count_times\`, \`count_with_zero_digits_pastes_correctly\`, \`count_100p_pastes_100_times\`, \`count_p_charwise_yank_pastes_count_times\`
  - \`crates/hjkl-compat-oracle/corpus/tier1.toml\`: \`register_yy_5p_pastes_five_times\`, \`register_yy_10p_pastes_ten_times\`, \`register_yy_3P_pastes_three_times_before\`, \`register_yl_5p_charwise_pastes_five_times\`
- [x] samply: \`render_picker_input_and_list\` / \`preview_render\` / \`Buffer::lines\` no longer dominate; remaining top is \`content_joined\` (genuine work) + \`render_window\`.

## Net change

**−2668 lines** (89 +, 3557 −) across 17 files.